### PR TITLE
Add "lnoravg" (log of marginal odds ratio) an built-in option to transform_pre in comparisons()

### DIFF
--- a/R/comparisons.R
+++ b/R/comparisons.R
@@ -58,6 +58,7 @@
 #'   - "lnratio": `function(hi, lo) log(hi / lo)`
 #'   - "ratioavg": `function(hi, lo) mean(hi) / mean(lo)`
 #'   - "lnratioavg": `function(hi, lo) log(mean(hi) / mean(lo))`
+#'   - "lnoravg": `function(hi, lo) log((mean(hi)/(1 - mean(hi))) / (mean(lo)/(1 - mean(lo))))`
 #' * function: accept two equal-length numeric vectors of adjusted predictions (`hi` and `lo`) and returns a vector of contrasts of the same length, or a unique numeric value.
 #' @param contrast_factor string. Which pairs of factors should be contrasted?
 #' * "reference": Each factor level is compared to the factor reference (base) level

--- a/R/sanitize_transform_pre.R
+++ b/R/sanitize_transform_pre.R
@@ -7,6 +7,7 @@ sanitize_transform_pre <- function(transform_pre) {
                                             "lnratio",
                                             "ratioavg",
                                             "lnratioavg",
+                                            "lnoravg",
                                             "differenceavg"))
     )
 
@@ -21,7 +22,8 @@ sanitize_transform_pre <- function(transform_pre) {
         "ratio" = function(hi, lo) hi / lo,
         "lnratio" = function(hi, lo) log(hi / lo),
         "ratioavg" = function(hi, lo) mean(hi) / mean(lo),
-        "lnratioavg" = function(hi, lo) log(mean(hi) / mean(lo))
+        "lnratioavg" = function(hi, lo) log(mean(hi) / mean(lo)),
+        "lnoravg" = function(hi, lo) {m_hi <- mean(hi); m_lo <- mean(lo); log((m_hi / (1 - m_hi)) / (m_lo / (1 - m_lo)))}
     )[[transform_pre]]
 
     lab <- list(
@@ -30,7 +32,8 @@ sanitize_transform_pre <- function(transform_pre) {
         "ratio" = "%s / %s",
         "lnratio" = "ln(%s / %s)",
         "ratioavg" = "mean(%s) / mean(%s)",
-        "lnratioavg" = "ln(mean(%s) / mean(%s))"
+        "lnratioavg" = "ln(mean(%s) / mean(%s))",
+        "lnoravg" = "ln(odds(%s) / odds(%s))"
     )[[transform_pre]]
 
     out <- list("label" = lab, "function" = fun)

--- a/vignettes/transformation.Rmd
+++ b/vignettes/transformation.Rmd
@@ -39,7 +39,7 @@ ggplot2::theme_set(theme_clean())
 
 This vignette shows how to move beyond such simple differences, by estimating "contrasts" that consist of ratios or arbitrary functions of adjusted predictions. It also shows how to back-transform contrasts to change their scales.
 
-Consider the case of a model with a single predictor $x$. To compute average contrasts, we procede as follows:
+Consider the case of a model with a single predictor $x$. To compute average contrasts, we proceed as follows:
 
 1. Compute adjusted predictions for each row of the dataset for the observed values $x$: $\hat{y}_x$
 2. Compute adjusted predictions for each row of the dataset for the observed values $x + 1$: $\hat{y}_{x+1}$
@@ -91,7 +91,7 @@ comparisons(mod, transform_pre = "ratio") %>% summary()
 
 This result is the average adjusted risk ratio, that is, the adjusted predictions when the `mpg` are incremented by 1, divided by the adjusted predictions when `mpg` is at its original value.
 
-The `transform_pre` accepts different values for common types of contrasts: 'difference', 'ratio', 'lnratio', 'ratioavg', 'lnratioavg', 'differenceavg'. These strings are shortcuts for functions that accept two vectors of adjusted predictions and returns a single vector of contrasts. For example, these two commands yield identical results:
+The `transform_pre` accepts different values for common types of contrasts: 'difference', 'ratio', 'lnratio', 'ratioavg', 'lnratioavg', 'lnoravg', 'differenceavg'. These strings are shortcuts for functions that accept two vectors of adjusted predictions and returns a single vector of contrasts. For example, these two commands yield identical results:
 
 ```{r}
 comparisons(mod, transform_pre = "ratio") %>% summary()


### PR DESCRIPTION
See #322 