### PR TITLE
Explicit predict instead of do.call

### DIFF
--- a/R/get_vcov.R
+++ b/R/get_vcov.R
@@ -82,7 +82,9 @@ get_vcov.default <- function(model,
             "Unable to extract a variance-covariance matrix using this `vcov`
             argument. Standard errors are computed using the default variance
             instead. Perhaps the model or argument is not supported by the
-            `sandwich` package.")
+            `sandwich` or `clubSandwich` packages. If you believe that the model
+            is supported by one of these two packages, you can open a feature
+            request on Github.")
             warning(msg, call. = FALSE)
         }
     }

--- a/R/methods_fixest.R
+++ b/R/methods_fixest.R
@@ -44,15 +44,30 @@ get_predict.fixest <- function(model,
         }
     }
 
-    args <- c(args, dots)
-    fun <- stats::predict
-    pred <- try(do.call("fun", args), silent = TRUE)
+    # args <- c(args, dots)
+    # fun <- stats::predict
+    # pred <- try(do.call("fun", args), silent = TRUE)
+    
+    pred <- try(predict(object = args$object, 
+                        newdata = args$newdata, 
+                        type = args$type, 
+                        interval = args$interval,
+                        level = args$level,
+                        vcov = args$vcov,
+                        ...),
+                silent = TRUE)
 
     # unable to compute confidence intervals; try again
     if (!is.null(conf_level) && inherits(pred, "try-error")) {
         args[["interval"]] <- "none"
         args[["level"]] <- NULL
-        pred <- try(do.call("fun", args), silent = TRUE)
+        pred <- try(predict(object = args$object, 
+                            newdata = args$newdata, 
+                            type = args$type, 
+                            interval = args$interval,
+                            vcov = args$vcov,
+                            ...),
+                    silent = TRUE)
     }
 
     if (inherits(pred, "data.frame")) {

--- a/inst/tinytest/test-pkg-fixest.R
+++ b/inst/tinytest/test-pkg-fixest.R
@@ -7,11 +7,14 @@ requiet("data.table")
 fixest::setFixest_nthreads(1)
 
 
-
 # Issue #375: friendly warning when sandwich fails
 mod <- feols(y ~ x1 + i(period, treat, 5) | id + period, base_did)
 hyp <- as.numeric(1:10 %in% 6:10)
-expect_warning(deltamethod(mod, hypothesis = hyp, vcov = "HC1"), pattern = "sandwich")
+# not supported
+expect_warning(deltamethod(mod, hypothesis = hyp, vcov = "HC0"), pattern = "sandwich")
+# supported
+d <- deltamethod(mod, hypothesis = hyp, vcov = "HC1")
+expect_inherits(d, "data.frame")
 
 # bugs stay dead: logit with transformations
 dat <- mtcars
@@ -33,11 +36,10 @@ expect_marginaleffects(mod2, pct_na = 62.5)
 expect_marginaleffects(mod3, pct_na = 62.5)
 expect_marginaleffects(mod4, pct_na = 62.5)
 
+# 20 observations for which we can't compute results
 mfx <- marginaleffects(mod1, variables = "mpg")
 expect_inherits(mfx, "marginaleffects")
-expect_equivalent(sum(is.na(mfx$dydx)), 20)
-expect_equivalent(sum(is.na(mfx$std.error)), 20)
-
+expect_equivalent(nrow(mfx), 12)
 
 
 # fixest::feols vs. Stata
@@ -86,6 +88,7 @@ mod1 <- feols(y ~ x * w | unit, data = dat)
 mod2 <- fixest::feols(y ~ x * w | unit, data = dat2)
 p <- plot_cme(mod2, effect = "x", condition = "w")
 expect_inherits(p, "ggplot")
+
 
 
 
@@ -155,7 +158,6 @@ mfx3 <- marginaleffects(fit3)
 expect_inherits(mfx1, "marginaleffects")
 expect_inherits(mfx2, "marginaleffects")
 expect_inherits(mfx3, "marginaleffects")
-
 
 # Issue #443: `newdata` breaks when it is a `data.table`
 d <- data.table(mtcars)
@@ -253,5 +255,6 @@ expect_inherits(m, "marginaleffects")
 # model <- feols(y ~ x1*x2 | group1^group2, data)
 # nd <- datagrid(model = model)
 # expect_error(marginaleffects(model, newdata = "mean"), "combined")
+
 
 


### PR DESCRIPTION
Following #485, here's an attempt to avoid using `do.call`s with `fixest`. Basically replacing the do.call with the explicit list of arguments, minus the `level` one in the second `do.call`. Not sure whether this is what you were thinking @vincentarelbundock. Tested with the workflow mentioned [here](https://github.com/vincentarelbundock/marginaleffects/issues/485#issuecomment-1245327633), returning:
```r
test-pkg-fixest.R.............    0 tests    0.3s [Exited at #3: problems testing fixest because of `get_data` from environment]
All ok, 0 results (0.3s)
```
Tested with the `N = 1e6` and it is indeed way faster. 