### PR TITLE
Small speedup

### DIFF
--- a/R/comparisons.R
+++ b/R/comparisons.R
@@ -112,7 +112,7 @@
 #' # Contrasts at user-specified values
 #' comparisons(mod, newdata = datagrid(am = 0, gear = tmp$gear))
 #' comparisons(mod, newdata = datagrid(am = unique, gear = max))
-#' 
+#'
 #' m <- lm(mpg ~ hp + drat + factor(cyl) + factor(am), data = mtcars)
 #' comparisons(m, variables = "hp", newdata = datagrid(FUN_factor = unique, FUN_numeric = median))
 #'
@@ -125,7 +125,7 @@
 #' comparisons(mod, variables = list(hp = "iqr")) %>% tidy()
 #' comparisons(mod, variables = list(hp = "sd")) %>% tidy()
 #' comparisons(mod, variables = list(hp = "minmax")) %>% tidy()
-#' 
+#'
 #' # using a function to specify a custom difference in one regressor
 #' dat <- mtcars
 #' dat$new_hp <- 49 * (dat$hp - min(dat$hp)) / (max(dat$hp) - min(dat$hp)) + 1
@@ -158,19 +158,19 @@
 #'     mod,
 #'     newdata = "mean",
 #'     hypothesis = "wt = drat")
-#' 
+#'
 #' # same hypothesis test using row indices
 #' comparisons(
 #'     mod,
 #'     newdata = "mean",
 #'     hypothesis = "b1 - b2 = 0")
-#' 
+#'
 #' # same hypothesis test using numeric vector of weights
 #' comparisons(
 #'     mod,
 #'     newdata = "mean",
 #'     hypothesis = c(1, -1))
-#' 
+#'
 #' # two custom contrasts using a matrix of weights
 #' lc <- matrix(c(
 #'     1, -1,
@@ -180,20 +180,20 @@
 #'     mod,
 #'     newdata = "mean",
 #'     hypothesis = lc)
-#' 
-#' 
+#'
+#'
 #' # `by` argument
 #' mod <- lm(mpg ~ hp * am * vs, data = mtcars)
 #' cmp <- comparisons(mod, variables = "hp", by = c("vs", "am"))
 #' summary(cmp)
-#' 
+#'
 #' library(nnet)
 #' mod <- multinom(factor(gear) ~ mpg + am * vs, data = mtcars, trace = FALSE)
 #' by <- data.frame(
 #'     group = c("3", "4", "5"),
 #'     by = c("3,4", "3,4", "5"))
 #' comparisons(mod, type = "probs", by = by)
-#' 
+#'
 #' @export
 comparisons <- function(model,
                         newdata = NULL,
@@ -268,7 +268,7 @@ comparisons <- function(model,
     sanity_dots(model, ...)
     checkmate::assert_numeric(eps, len = 1, lower = 1e-10, null.ok = TRUE)
 
-    # used by `marginaleffects` to hard-code preference 
+    # used by `marginaleffects` to hard-code preference
     # deprecated as user-level arguments
     if ("contrast_factor" %in% names(dots)) {
         contrast_factor <- dots[["contrast_factor"]]
@@ -283,7 +283,7 @@ comparisons <- function(model,
         contrast_numeric <- 1
     }
 
-    marginalmeans <- isTRUE(checkmate::check_choice(newdata, choices = "marginalmeans")) 
+    marginalmeans <- isTRUE(checkmate::check_choice(newdata, choices = "marginalmeans"))
 
     # before sanitize_variables
     newdata <- sanitize_newdata(model = model, newdata = newdata, by = by)
@@ -317,7 +317,7 @@ comparisons <- function(model,
     if (is.character(vcov) &&
        # get_df() produces a weird warning on non lmerMod. We can skip them
        # because get_vcov() will produce an informative error later.
-       inherits(model, "lmerMod") && 
+       inherits(model, "lmerMod") &&
        (isTRUE(vcov == "satterthwaite") || isTRUE(vcov == "kenward-roger"))) {
         df <- insight::find_response(model)
         # predict.lmerTest requires the DV
@@ -404,7 +404,7 @@ comparisons <- function(model,
             tmp <- contrast_data$original[, ..idx, drop = FALSE]
             # contrast_data is duplicated to compute contrasts for different terms or pairs
             bycols <- intersect(colnames(tmp), colnames(mfx))
-            idx <- apply(tmp[, ..bycols], 1, paste, collapse = "|")
+            idx <- do.call(paste, c(tmp[, ..bycols], sep = "|"))
             tmp <- tmp[!duplicated(idx), , drop = FALSE]
             mfx <- merge(mfx, tmp, all.x = TRUE, by = bycols, sort = FALSE)
         # HACK: relies on NO sorting at ANY point


### PR DESCRIPTION
Hello Vincent,

`do.call()` + `paste()` is generally faster than `apply()` + `paste()` (that is used in `comparisons()`). It only creates a marginal gain but better than nothing. I used some of the benchmarks of the [vignette on performance](https://vincentarelbundock.github.io/marginaleffects/articles/performance.html). 

### Current (`apply`)

``` r
library(marginaleffects)

# simulate data and fit a large model
N <- 1e5
dat <- data.frame(matrix(rnorm(N * 26), ncol = 26))
mod <- lm(X1 ~ ., dat)

bench::mark(
  marginaleffects(mod, vcov = FALSE, variables = "X3"),
  marginaleffects(mod, variables = "X3"),
  iterations = 10,
  check = FALSE
)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 × 6
#>   expression                                                min   median itr/s…¹
#>   <bch:expr>                                           <bch:tm> <bch:tm>   <dbl>
#> 1 marginaleffects(mod, vcov = FALSE, variables = "X3")    1.05s    1.16s   0.866
#> 2 marginaleffects(mod, variables = "X3")                  5.63s    6.69s   0.152
#> # … with 2 more variables: mem_alloc <bch:byt>, `gc/sec` <dbl>, and abbreviated
#> #   variable name ¹​`itr/sec`
```

### New (`do.call`)

``` r
library(marginaleffects)

# simulate data and fit a large model
N <- 1e5
dat <- data.frame(matrix(rnorm(N * 26), ncol = 26))
mod <- lm(X1 ~ ., dat)

bench::mark(
  marginaleffects(mod, vcov = FALSE, variables = "X3"),
  marginaleffects(mod, variables = "X3"),
  iterations = 10,
  check = FALSE
)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 × 6
#>   expression                                                min   median itr/s…¹
#>   <bch:expr>                                           <bch:tm> <bch:tm>   <dbl>
#> 1 marginaleffects(mod, vcov = FALSE, variables = "X3") 615.74ms 674.88ms   1.48 
#> 2 marginaleffects(mod, variables = "X3")                  5.37s    5.94s   0.169
#> # … with 2 more variables: mem_alloc <bch:byt>, `gc/sec` <dbl>, and abbreviated
#> #   variable name ¹​`itr/sec`
```

--- 

Regarding tests, a lot of them didn't run because `ON_CRAN` was true (which obviously wasn't). I think the problem comes from `inst/tinytest/helpers.R`:
https://github.com/vincentarelbundock/marginaleffects/blob/9b5dfdaa28c13bbe74a87745bedf29cd7bd5fa0b/inst/tinytest/helpers.R#L16

~~Shouldn't you remove the `!` at the beginning?~~ Actually it was because `Sys.getenv("R_NOT_CRAN")` return `""` in my case

(Also I have no idea why some spaces were removed on other lines)