### PR TITLE
Fixing the Bayesian Model Averaging Link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ External links:
   - [Subgroup Analysis After Propensity Score Matching Using
     R](https://ngreifer.github.io/blog/subgroup-analysis-psm/) by Noah
     Greifer
-  - [Bayesian model
-    averaging](https://www.ajordannafa.com/blog/2022/05/24/bma-ames/) by
+  - [Bayesian Model
+    Averaged Marginal Effects](https://www.ajordannafa.com/blog/2022/being-less-wrong/) by
     A. Jordan Nafa
 
 ## Motivation

--- a/vignettes/toc_external.Rmd
+++ b/vignettes/toc_external.Rmd
@@ -3,4 +3,4 @@
 - [Matching](https://cran.r-project.org/web/packages/MatchIt/vignettes/estimating-effects.html) by Noah Greifer
 - [Double propensity score adjustment using g-computation](https://stats.stackexchange.com/questions/580118/adjusting-the-model-by-propensity-scores-after-propensity-score-matching/580174#580174) by Noah Greifer
 - [Subgroup Analysis After Propensity Score Matching Using R](https://ngreifer.github.io/blog/subgroup-analysis-psm/) by Noah Greifer
-- [Bayesian model averaging](https://www.ajordannafa.com/blog/2022/05/24/bma-ames/) by A. Jordan Nafa
+- [Bayesian Model Averaged Marginal Effects](https://www.ajordannafa.com/blog/2022/being-less-wrong/) by A. Jordan Nafa


### PR DESCRIPTION
This is just a simple fix to the README file to update the link for my Bayesian Model Averaged Marginal Effects blog post.