### PR TITLE
Improve the performance of `get_predict()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: marginaleffects
 Title: Predictions, Comparisons, Slopes, Marginal Means, and Hypothesis Tests
-Version: 0.9.0
+Version: 0.9.0.9000
 Authors@R: 
     c(person(given = "Vincent",
              family = "Arel-Bundock",
@@ -16,7 +16,11 @@ Authors@R:
              family = "Greifer",
              role = "ctb",
              email = "noah.greifer@gmail.com",
-             comment = c(ORCID = "0000-0003-3067-7154")))
+             comment = c(ORCID = "0000-0003-3067-7154")),
+      person("Etienne", "Bacher",
+             email = "etienne.bacher@protonmail.com",
+             role = "ctb",
+             comment = c(ORCID = "0000-0002-9271-5075"))))
 Description: Compute and plot predictions, slopes, marginal means, and comparisons (contrasts, risk ratios, odds, etc.) for over 70 classes of statistical models in R. Conduct linear and non-linear hypothesis tests, or equivalence tests. Calculate uncertainty estimates using the delta method, bootstrapping, or simulation-based inference.
 License: GPL (>= 3)
 Copyright: inst/COPYRIGHTS

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# marginaleffects 0.9.0.9000
+
+Other:
+
+* Improved the performance of `slopes()`, in particular when `vcov = TRUE`. Thanks
+  to Etienne Bacher.
+
 # marginaleffects 0.9.0
 
 Breaking changes:

--- a/R/get_predict.R
+++ b/R/get_predict.R
@@ -140,7 +140,10 @@ get_predict.default <- function(model,
     if (isTRUE(checkmate::check_atomic_vector(pred))) {
         # strip weird attributes added by some methods (e.g., predict.svyglm)
         if (length(pred) == nrow(newdata)) {
-            if (!is.numeric(pred)) pred <- as.numeric(pred)
+            # as.numeric is slow with large objects and we can't use is.numeric
+            # to run it conditionally because objects of class "svystat" are
+            # already numeric
+            class(pred) <- "numeric"
             if ("rowid" %in% colnames(newdata)) {
                 out <- list(estimate = pred,
                                   rowid = newdata$rowid)

--- a/R/get_predict.R
+++ b/R/get_predict.R
@@ -2,7 +2,7 @@
 #'
 #' @return A data.frame of predicted values with a number of rows equal to the
 #' number of rows in `newdata` and columns "rowid" and "estimate". A "group"
-#' column is added for multivariate models or models with categorical outcomes. 
+#' column is added for multivariate models or models with categorical outcomes.
 #' @rdname get_predict
 #' @inheritParams slopes
 #' @keywords internal
@@ -140,11 +140,12 @@ get_predict.default <- function(model,
     if (isTRUE(checkmate::check_atomic_vector(pred))) {
         # strip weird attributes added by some methods (e.g., predict.svyglm)
         if (length(pred) == nrow(newdata)) {
+            if (!is.numeric(pred)) pred <- as.numeric(pred)
             if ("rowid" %in% colnames(newdata)) {
-                out <- data.table(estimate = as.numeric(pred),
+                out <- list(estimate = pred,
                                   rowid = newdata$rowid)
             } else {
-                out <- data.table(estimate = as.numeric(pred),
+                out <- list(estimate = pred,
                                   rowid = seq_len(length(pred)))
             }
         }
@@ -153,12 +154,12 @@ get_predict.default <- function(model,
     } else if (is.matrix(pred)) {
         # internal calls always includes "rowid" as a column in `newdata`
         if ("rowid" %in% colnames(newdata)) {
-            out <- data.table(
+            out <- list(
                 rowid = rep(newdata[["rowid"]], times = ncol(pred)),
                 group = rep(colnames(pred), each = nrow(pred)),
                 estimate = c(pred))
         } else {
-            out <- data.table(
+            out <- list(
                 rowid = rep(seq_len(nrow(pred)), times = ncol(pred)),
                 group = rep(colnames(pred), each = nrow(pred)),
                 estimate = c(pred))


### PR DESCRIPTION
Two things:

1. Creating a `data.table()` takes some time and is not necessary in `get_predict()` because there’s no `data.table`-specific operations. It is faster to create a list, which is also accepted by `setDF()`. 
2. If I'm not mistaken, the only reason why you use `as.numeric(pred)` is because of `svyglm` which returns an object of class `svystat`. It's faster to directly assign the class "numeric" when there are a lot of observations.

These improve the performance mostly when `vcov = TRUE`.

I use the same setup as in the [performance vignette](https://vincentarelbundock.github.io/marginaleffects/articles/performance.html) but with less observations because it takes quite some time to run all these benchmarks.

### Before

``` r
library(marginaleffects)

# simulate data and fit a large model
N <- 3*1e4
dat <- data.frame(matrix(rnorm(N * 26), ncol = 26))
mod <- lm(X1 ~ ., dat)

results <- bench::mark(
  # marginal effects at the mean; no standard error
  slopes(mod, vcov = FALSE, newdata = "mean"),
  # marginal effects at the mean
  slopes(mod, newdata = datagrid()),
  # 1 variable; no standard error
  slopes(mod, vcov = FALSE, variables = "X3"),
  # 1 variable
  slopes(mod, variables = "X3"),
  # 26 variables; no standard error
  slopes(mod, vcov = FALSE),
  # 26 variables
  slopes(mod),
  iterations = 10,
  check = FALSE
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.

results[, c(1, 3, 5)]
#> # A tibble: 6 × 3
#>   expression                                    median mem_alloc
#>   <bch:expr>                                  <bch:tm> <bch:byt>
#> 1 slopes(mod, vcov = FALSE, newdata = "mean") 419.16ms  415.82MB
#> 2 slopes(mod, newdata = datagrid())           668.29ms  421.67MB
#> 3 slopes(mod, vcov = FALSE, variables = "X3") 305.74ms  212.78MB
#> 4 slopes(mod, variables = "X3")                  2.06s    1.23GB
#> 5 slopes(mod, vcov = FALSE)                      6.71s    4.13GB
#> 6 slopes(mod)                                   41.76s   28.59GB
```

### After

``` r
results[, c(1, 3, 5)]
#> # A tibble: 6 × 3
#>   expression                                    median mem_alloc
#>   <bch:expr>                                  <bch:tm> <bch:byt>
#> 1 slopes(mod, vcov = FALSE, newdata = "mean") 350.68ms  417.65MB
#> 2 slopes(mod, newdata = datagrid())           611.66ms  420.85MB
#> 3 slopes(mod, vcov = FALSE, variables = "X3") 210.24ms  211.24MB
#> 4 slopes(mod, variables = "X3")                  1.44s     1.2GB
#> 5 slopes(mod, vcov = FALSE)                      5.38s    4.09GB
#> 6 slopes(mod)                                   28.99s    27.8GB
```

