### PR TITLE
`poorman` tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -106,6 +106,7 @@ Suggests:
     pkgdown,
     plm,
     polspline,
+    poorman,
     posterior,
     prediction,
     pscl,

--- a/inst/tinytest/helpers.R
+++ b/inst/tinytest/helpers.R
@@ -32,36 +32,27 @@ options(width = 10000)
 options(digits = 5)
 
 # important because otherwise testing so many packages is terrible
-dict <- c(
-    "contrast" = "emmeans",
-    "expect_error" = "tinytest",
-    "expect_true" = "tinytest",
-    "expect_equal" = "tinytest",
-    "expect_warning" = "tinytest",
-    "summary" = "base",
-    "lmer" = "lme4",
-    "s" = "gam",
-    "ar" = "stats",
-    "dof" = "parameters",
-    "marginal_effects" = "margins",
-    "kidney" = "brms",
-    "ngrps" = "brms",
-    "filter" = "dplyr",
-    "lag" = "dplyr",
-    "recode" = "dplyr",
-    "logit" = "boot",
-    "melanoma" = "boot",
-    "lizards" = "aod",
-    "rats" = "aod",
-    "aml" = "survival",
-    "mad" = "stats",
-    "sd" = "stats",
-    "var" = "stats"
-)
-conflicted::conflict_prefer_all("dplyr", quiet = TRUE)
-for (i in seq_along(dict)) {
-    conflicted::conflict_prefer(name = names(dict)[i], winner = dict[i], quiet = TRUE)
-}
+# dict <- c(
+    # "summary" = "base",
+    # "ar" = "stats",
+    # "dof" = "parameters",
+    # "marginal_effects" = "margins",
+#     "kidney" = "brms",
+#     "ngrps" = "brms",
+#     "logit" = "boot",
+#     "melanoma" = "boot",
+#     "lizards" = "aod",
+#     "rats" = "aod",
+#     "aml" = "survival",
+#     "mad" = "stats",
+#     "sd" = "stats",
+#     "var" = "stats"
+# )
+# conflicted::conflict_prefer_all("tinytest", quiet = TRUE)
+# conflicted::conflict_prefer_all("poorman", quiet = TRUE)
+# for (i in seq_along(dict)) {
+#     conflicted::conflict_prefer(name = names(dict)[i], winner = dict[i], quiet = TRUE)
+# }
 
 
 ON_CRAN <- !identical(Sys.getenv("R_NOT_CRAN"), "true")

--- a/inst/tinytest/test-datagrid.R
+++ b/inst/tinytest/test-datagrid.R
@@ -9,7 +9,7 @@ exit_if_not(requiet("fixest"))
 expect_error(datagrid(Petal.Length = 4.6), pattern = "inside")
 
 # numeric clusters no longer produce a warning; selects mode
-mod <- lmer(mpg ~ hp + (1 + drat | cyl), data = mtcars)
+mod <-lme4::lmer(mpg ~ hp + (1 + drat | cyl), data = mtcars)
 expect_true(datagrid(model = mod)$cyl == 8)
 
 # functions

--- a/inst/tinytest/test-dots.R
+++ b/inst/tinytest/test-dots.R
@@ -4,7 +4,7 @@ using("marginaleffects")
 exit_if_not(requiet("lme4"))
 
 # lme4::lmer
-mod <- lmer(mpg ~ hp + (1 | gear), data = mtcars)
+mod <-lme4::lmer(mpg ~ hp + (1 | gear), data = mtcars)
 expect_inherits(slopes(mod), "marginaleffects")
 expect_warning(slopes(mod, blah = 2), pattern = "Github")
 

--- a/inst/tinytest/test-equivalence.R
+++ b/inst/tinytest/test-equivalence.R
@@ -1,5 +1,5 @@
 source("helpers.R")
-requiet("dplyr")
+requiet("poorman")
 requiet("emmeans")
 requiet("parameters")
 
@@ -14,7 +14,7 @@ e2 <- predictions(
     mod,
     newdata = datagrid(gear = unique),
     equivalence = c(19, 21)) |>
-    dplyr::arrange(gear)
+    poorman::arrange(gear)
 expect_equivalent(e1$z.ratio, e2$statistic.noninf)
 expect_equivalent(e1$p.value, e2$p.value.noninf)
 
@@ -25,7 +25,7 @@ e2 <- predictions(
     mod,
     newdata = datagrid(gear = unique),
     equivalence = c(22, 24)) |>
-    dplyr::arrange(gear)
+    poorman::arrange(gear)
 expect_equivalent(e1$z.ratio, e2$statistic.nonsup)
 expect_equivalent(e1$p.value, e2$p.value.nonsup)
 
@@ -36,7 +36,7 @@ e2 <- predictions(
     mod,
     newdata = datagrid(gear = unique),
     equivalence = c(21, 23)) |>
-    dplyr::arrange(gear)
+    poorman::arrange(gear)
 expect_equivalent(e1$p.value, e2$p.value.equiv)
 
 
@@ -104,7 +104,7 @@ e2 <- predictions(
     type = "link",
     newdata = datagrid(gear = unique),
     equivalence = c(.5, 1.5)) |>
-    dplyr::arrange(gear)
+    poorman::arrange(gear)
 expect_equivalent(e1$emmean, e2$estimate)
 expect_equivalent(e1$z.ratio, e2$statistic.noninf)
 expect_equivalent(e1$p.value, e2$p.value.noninf)

--- a/inst/tinytest/test-hypothesis.R
+++ b/inst/tinytest/test-hypothesis.R
@@ -125,7 +125,7 @@ expect_equivalent(p3$term, c("Contrast A", "Contrast B"))
 # marginalmeans: hypothesis complex
 lc <- c(-2, 1, 1, 0, -1, 1)
 em <- emmeans(mod, "carb") 
-em <- contrast(em, method = data.frame(custom_contrast = lc))
+em <- emmeans::contrast(em, method = data.frame(custom_contrast = lc))
 em <- data.frame(em)
 mm <- marginal_means(mod, variables = "carb", hypothesis = lc)
 expect_equivalent(mm$estimate, em$estimate)

--- a/inst/tinytest/test-newdata.R
+++ b/inst/tinytest/test-newdata.R
@@ -41,7 +41,7 @@ cmp <- comparisons(mod, newdata = "marginalmeans", variables = "gear")
 cmp <- tidy(cmp)
 
 emm <- emmeans(mod, specs = "gear")
-emm <- data.frame(contrast(emm, method = "trt.vs.ctrl1"))
+emm <- data.frame(emmeans::contrast(emm, method = "trt.vs.ctrl1"))
 
 expect_equivalent(cmp$estimate, emm$estimate)
 expect_equivalent(cmp$std.error, emm$SE)
@@ -62,7 +62,7 @@ expect_equivalent(cmp$std.error, emm$SE)
 #     variables = list(species = "pairwise", island = "pairwise"))
 
 # emm <- emmeans(mod, specs = c("species", "island"))
-# emm <- data.frame(contrast(emm, method = "trt.vs.ctrl1"))
+# emm <- data.frame(emmeans::contrast(emm, method = "trt.vs.ctrl1"))
 
 # # hack: not sure if they are well aligned
 # expect_equivalent(sort(cmp$estimate), sort(emm$estimate))

--- a/inst/tinytest/test-pkg-MASS.R
+++ b/inst/tinytest/test-pkg-MASS.R
@@ -59,7 +59,7 @@ expect_equivalent(mfx$std.error[1], em$std.error, tolerance = 1e-3)
 # emmeans contrasts
 mfx <- slopes(model, type = "link", newdata = datagrid(wt = 3, cyl = 4))
 em <- emmeans(model, specs = "cyl") 
-em <- contrast(em, method = "revpairwise", at = list(wt = 3, cyl = 4))
+em <- emmeans::contrast(em, method = "revpairwise", at = list(wt = 3, cyl = 4))
 em <- tidy(em)
 expect_equivalent(mfx$estimate[mfx$contrast == "6 - 4"], em$estimate[em$contrast == "cyl6 - cyl4"])
 expect_equivalent(mfx$std.error[mfx$contrast == "6 - 4"], em$std.error[em$contrast == "cyl6 - cyl4"])

--- a/inst/tinytest/test-pkg-afex.R
+++ b/inst/tinytest/test-pkg-afex.R
@@ -29,7 +29,7 @@ cmp <- comparisons(mod,
     variables = "angle",
     newdata = "marginalmeans")
 em <- emmeans(mod, ~angle)
-em <- contrast(em, method = "trt.vs.ctrl1")
+em <- emmeans::contrast(em, method = "trt.vs.ctrl1")
 em <- data.frame(em)
 expect_equal(cmp$estimate, em$estimate)
 expect_equal(cmp$std.error, em$SE)

--- a/inst/tinytest/test-pkg-brms.R
+++ b/inst/tinytest/test-pkg-brms.R
@@ -49,8 +49,8 @@ tmp$cat <- as.factor(sample(1:5, size = 180, replace = TRUE))
 tmp$Reaction_d <-
   ifelse(tmp$Reaction < median(tmp$Reaction), 0, 1)
 tmp <- tmp |>
-  dplyr::group_by(grp) |>
-  dplyr::mutate(subgrp = sample(1:15, size = dplyr::n(), replace = TRUE))
+  poorman::group_by(grp) |>
+  poorman::mutate(subgrp = sample(1:15, size = poorman::n(), replace = TRUE))
 void <- capture.output(suppressMessages(
     brms_mixed_3 <- brm(Reaction ~ Days + (1 | grp / subgrp) + (1 | Subject), data = tmp)
 ))

--- a/inst/tinytest/test-pkg-gam.R
+++ b/inst/tinytest/test-pkg-gam.R
@@ -7,7 +7,7 @@ exit_if_not(requiet("broom"))
 
 # gam: marginaleffects vs. emtrends
 data(kyphosis, package = "gam")
-model <- gam::gam(Kyphosis ~ s(Age,4) + Number, family = binomial, data = kyphosis)
+model <- gam::gam(Kyphosis ~ gam::s(Age,4) + Number, family = binomial, data = kyphosis)
 expect_slopes(model)
 
 # emmeans
@@ -21,7 +21,7 @@ expect_equivalent(mfx$std.error, em$std.error, tolerance = .001)
 
 # gam: predictions: no validity
 data(kyphosis, package = "gam")
-model <- gam::gam(Kyphosis ~ s(Age, 4) + Number,
+model <- gam::gam(Kyphosis ~ gam::s(Age, 4) + Number,
             family = binomial, data = kyphosis)
 pred1 <- predictions(model)
 pred2 <- predictions(model, newdata = head(kyphosis))

--- a/inst/tinytest/test-pkg-ivreg.R
+++ b/inst/tinytest/test-pkg-ivreg.R
@@ -2,7 +2,7 @@ source("helpers.R")
 using("marginaleffects")
 
 exit_if_not(requiet("margins"))
-exit_if_not(requiet("dplyr"))
+exit_if_not(requiet("poorman"))
 exit_if_not(requiet("ivreg"))
 
 # marginaleffects: vs. margins
@@ -25,10 +25,10 @@ dat <- read.csv(testing_path("stata/databases/ivreg_ivreg_01.csv"))
 stata <- readRDS(testing_path("stata/stata.rds"))[["ivreg_ivreg_01"]]
 mod <- ivreg::ivreg(Q ~ P + D | D + F + A, data = dat)
 ame <- slopes(mod) |>
-   dplyr::group_by(term) |>
-   dplyr::summarize(estimate = mean(estimate),
+   poorman::group_by(term) |>
+   poorman::summarize(estimate = mean(estimate),
              std.error = mean(std.error)) |>
-   dplyr::inner_join(stata, by = "term")
+   poorman::inner_join(stata, by = "term")
 expect_equivalent(ame$estimate, ame$dydxstata, tolerance = 0.0001)
 
 

--- a/inst/tinytest/test-pkg-lme4.R
+++ b/inst/tinytest/test-pkg-lme4.R
@@ -14,7 +14,7 @@ exit_if_not(requiet("broom"))
 dat <- mtcars
 dat$cyl <- factor(dat$cyl)
 dat <- dat
-mod <- lmer(mpg ~ hp + (1 | cyl), data = dat)
+mod <-lme4::lmer(mpg ~ hp + (1 | cyl), data = dat)
 x <- predictions(mod)
 y <- predictions(mod, vcov = "satterthwaite")
 z <- predictions(mod, vcov = "kenward-roger")
@@ -126,7 +126,7 @@ expect_equivalent(w, y$estimate)
 # incompatible arguments
 expect_error(get_predict(mod, re.form = ~0, include_random = TRUE), pattern = "together")
 
-# lmer vs. stata
+#lme4::lmer vs. stata
 tmp <- read.csv(testing_path("stata/databases/lme4_01.csv"))
 mod <- lme4::lmer(y ~ x1 * x2 + (1 | clus), data = tmp)
 stata <- readRDS(testing_path("stata/stata.rds"))$lme4_lmer
@@ -136,7 +136,7 @@ expect_equivalent(mfx$estimate, mfx$dydxstata, tolerance = .001)
 expect_equivalent(mfx$std.error, mfx$std.errorstata, tolerance = .001)
 
 # emtrends
-mod <- lmer(y ~ x1 + x2 + (1 | clus), data = tmp)
+mod <-lme4::lmer(y ~ x1 + x2 + (1 | clus), data = tmp)
 mfx <- slopes(mod, variables = "x1",
                    newdata = datagrid(x1 = 0, x2 = 0, clus = 1))
 em <- emtrends(mod, ~x1, "x1", at = list(x1 = 0, x2 = 0, clus = 1))
@@ -281,7 +281,7 @@ tmp <- mtcars
 tmp$cyl <- factor(tmp$cyl)
 tmp$am <- as.logical(tmp$am)
 tmp <- tmp
-mod <- lmer(mpg ~ hp + am + (1 | cyl), data = tmp)
+mod <-lme4::lmer(mpg ~ hp + am + (1 | cyl), data = tmp)
 
 mfx <- slopes(mod, vcov = "kenward-roger")
 cmp <- comparisons(mod, vcov = "kenward-roger")
@@ -295,7 +295,7 @@ expect_equivalent(attr(cmp, "vcov.type"), "Kenward-Roger")
 
 
 # # Issue 437: allow `get_predicted()` arguments
-# mod <- lmer(mpg ~ hp + (1 | cyl), data = mtcars)
+# mod <-lme4::lmer(mpg ~ hp + (1 | cyl), data = mtcars)
 # p1 <- predictions(mod, type = "prediction")
 # p2 <- predictions(mod)
 # expect_inherits(p1, "predictions")

--- a/inst/tinytest/test-pkg-lmerTest.R
+++ b/inst/tinytest/test-pkg-lmerTest.R
@@ -8,7 +8,7 @@ exit_if_not(requiet("margins"))
 
 # vs. emmeans vs. margins
 dat <- read.csv(testing_path("stata/databases/lme4_02.csv"))
-mod <- lmer(y ~ x1 * x2 + (1 | clus), data = dat)
+mod <-lme4::lmer(y ~ x1 * x2 + (1 | clus), data = dat)
 
 # no validity
 expect_slopes(mod)

--- a/inst/tinytest/test-pkg-stats.R
+++ b/inst/tinytest/test-pkg-stats.R
@@ -4,7 +4,7 @@ using("marginaleffects")
 exit_if_not(requiet("margins"))
 exit_if_not(requiet("broom"))
 exit_if_not(requiet("emmeans"))
-exit_if_not(requiet("dplyr"))
+exit_if_not(requiet("poorman"))
 
 
 guerry <- read.csv("https://vincentarelbundock.github.io/Rdatasets/csv/HistData/Guerry.csv")

--- a/inst/tinytest/test-summary.R
+++ b/inst/tinytest/test-summary.R
@@ -57,7 +57,7 @@ mod <- glm(am ~ hp * wt, data = dat, family = binomial)
 mfx <- slopes(mod)
 expect_snapshot_print(
     summary(mfx) |> poorman::select(term, estimate, conf.low, conf.high),
-    "summary-marginaleffects_poorman")
+    "summary-marginaleffects_dplyr")
 
 
 # bugs stay dead: label transformation_post

--- a/inst/tinytest/test-summary.R
+++ b/inst/tinytest/test-summary.R
@@ -5,7 +5,7 @@ exit_if_not(!ON_OSX)
 using("tinyviztest")
 using("marginaleffects")
 
-exit_if_not(requiet("dplyr"))
+exit_if_not(requiet("poorman"))
 
 dat <- mtcars
 mod <- glm(am ~ hp, data = dat, family = binomial)
@@ -56,8 +56,8 @@ dat <- mtcars
 mod <- glm(am ~ hp * wt, data = dat, family = binomial)
 mfx <- slopes(mod)
 expect_snapshot_print(
-    summary(mfx) |> dplyr::select(term, estimate, conf.low, conf.high),
-    "summary-marginaleffects_dplyr")
+    summary(mfx) |> poorman::select(term, estimate, conf.low, conf.high),
+    "summary-marginaleffects_poorman")
 
 
 # bugs stay dead: label transformation_post

--- a/vignettes/marginaleffects.Rmd
+++ b/vignettes/marginaleffects.Rmd
@@ -132,7 +132,7 @@ mfx
 
 # Grid
 
-Predictions, comparisons, and slopes are typically "conditional" quantities which depend on the values of all the predictors in the model. By default, `marginaleffects` functions estimate quantities of interest for empirical distribution of the data (i.e., for each row of the original dataset). However, users can specify the exact values of the predictors they want to investigate by using the `newdata` argument.
+Predictions, comparisons, and slopes are typically "conditional" quantities which depend on the values of all the predictors in the model. By default, `marginaleffects` functions estimate quantities of interest for the empirical distribution of the data (i.e., for each row of the original dataset). However, users can specify the exact values of the predictors they want to investigate by using the `newdata` argument.
 
 `newdata` accepts data frames, shortcut strings, or a call to the `datagrid()` function. For example, to compute the predicted outcome for a hypothetical car with all predictors equal to the sample mean or median, we can do:
 


### PR DESCRIPTION
As noted here: https://github.com/vincentarelbundock/marginaleffects/issues/634

`dplyr` significantly slows down the tests. I suspect this also had something to do with `conflicted`. Removed both, added some namespaces, and switched some calls to the wonderful `poorman` package.