### PR TITLE
Improve speed of `predictions()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: marginaleffects
 Title: Predictions, Comparisons, Slopes, Marginal Means, and Hypothesis Tests
-Version: 0.9.0.9002
+Version: 0.9.0.9003
 Authors@R: 
     c(person(given = "Vincent",
              family = "Arel-Bundock",

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,8 @@ New models supported:
 
 Other:
 
-* Improved the performance of `slopes()`, in particular when `vcov = TRUE`. Thanks to Etienne Bacher.
+* Improved the performance of `slopes()`, in particular when `vcov = TRUE` and 
+  of `predictions()`. Thanks to Etienne Bacher.
 
 Bugfixes:
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@ New models supported:
 
 Other:
 
-* Improved the performance of `slopes()`, in particular when `vcov = TRUE` and 
+* Improved the performance of `slopes()`, in particular when `vcov = TRUE`, and 
   of `predictions()`. Thanks to Etienne Bacher.
 
 Bugfixes:

--- a/R/datagrid.R
+++ b/R/datagrid.R
@@ -165,7 +165,6 @@ counterfactual <- function(..., model = NULL, newdata = NULL) {
         dat_automatic[, rowidcf := rowid$rowidcf]
         setcolorder(dat_automatic, c("rowidcf", setdiff(names(dat_automatic), "rowidcf")))
         # cross-join 2 data.tables, faster than merging two dataframes
-        # https://stackoverflow.com/questions/75361701/merging-two-data-tables-that-dont-have-common-columns
         out <- cjdt(list(dat_automatic, at))
     }  else {
         out <- merge(rowid, at, all = TRUE)

--- a/R/datagrid.R
+++ b/R/datagrid.R
@@ -1,6 +1,6 @@
 #' Data grids
-#' 
-#' @description 
+#'
+#' @description
 #' Generate a data grid of user-specified values for use in the `newdata` argument of the `predictions()`, `comparisons()`, and `slopes()` functions. This is useful to define where in the predictor space we want to evaluate the quantities of interest. Ex: the predicted outcome or slope for a 37 year old college graduate.
 #'
 #' * `datagrid()` generates data frames with combinations of "typical" or user-supplied predictor values.
@@ -23,7 +23,7 @@
 #' @param FUN_other the function to be applied to other variable types.
 #' @details
 #' If `datagrid` is used in a `predictions()`, `comparisons()`, or `slopes()` call as the
-#' `newdata` argument, the model is automatically inserted in the `model` argument of `datagrid()` 
+#' `newdata` argument, the model is automatically inserted in the `model` argument of `datagrid()`
 #' call, and users do not need to specify either the `model` or `newdata` arguments.
 #'
 #' If users supply a model, the data used to fit that model is retrieved using
@@ -116,7 +116,7 @@ datagrid <- function(
 #' Counterfactual data grid
 #' @describeIn datagrid Counterfactual data grid
 #' @export
-#' 
+#'
 datagridcf <- function(
     ...,
     model = NULL,
@@ -137,7 +137,7 @@ datagridcf <- function(
     attr(out, "variables_datagrid") <- names(out)
 
     return(out)
-        
+
 }
 
 
@@ -162,8 +162,11 @@ counterfactual <- function(..., model = NULL, newdata = NULL) {
     if (length(variables_automatic) > 0) {
         idx <- intersect(variables_automatic, colnames(dat))
         dat_automatic <- dat[, ..idx, drop = FALSE]
-        dat_automatic <- cbind(rowid, dat_automatic)
-        out <- merge(dat_automatic, at, all = TRUE)
+        dat_automatic[, rowidcf := rowid$rowidcf]
+        setcolorder(dat_automatic, c("rowidcf", setdiff(names(dat_automatic), "rowidcf")))
+        # cross-join 2 data.tables, faster than merging two dataframes
+        # https://stackoverflow.com/questions/75361701/merging-two-data-tables-that-dont-have-common-columns
+        out <- setkey(dat_automatic[, c(k=1, .SD)], k)[at[, c(k = 1, .SD)], allow.cartesian = TRUE][, k := NULL]
     }  else {
         out <- merge(rowid, at, all = TRUE)
     }

--- a/R/datagrid.R
+++ b/R/datagrid.R
@@ -166,7 +166,7 @@ counterfactual <- function(..., model = NULL, newdata = NULL) {
         setcolorder(dat_automatic, c("rowidcf", setdiff(names(dat_automatic), "rowidcf")))
         # cross-join 2 data.tables, faster than merging two dataframes
         # https://stackoverflow.com/questions/75361701/merging-two-data-tables-that-dont-have-common-columns
-        out <- setkey(dat_automatic[, c(k=1, .SD)], k)[at[, c(k = 1, .SD)], allow.cartesian = TRUE][, k := NULL]
+        out <- cjdt(list(dat_automatic, at))
     }  else {
         out <- merge(rowid, at, all = TRUE)
     }


### PR DESCRIPTION
Benchmark:
``` r
library(marginaleffects)

tmp <- list()
for (i in 1:30000) {
  tmp[[i]] <- mtcars
}
tmp2 <- data.table::rbindlist(tmp)
tmp2$am <- as.logical(tmp2$am)
dim(tmp2)
#> [1] 960000     11

mod <- lm(mpg ~ hp + factor(cyl), data = tmp2)
```
Old:
```r
bench::mark(
  predictions(mod, variables = list(hp = c(100, 120))),
  predictions(mod, newdata = datagridcf(hp = c(100, 120), cyl = c(4, 6))),
  check = FALSE
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 × 6
#>   expression                                                                 min
#>   <bch:expr>                                                              <bch:>
#> 1 predictions(mod, variables = list(hp = c(100, 120)))                     12.4s
#> 2 predictions(mod, newdata = datagridcf(hp = c(100, 120), cyl = c(4, 6)))  21.2s
#> # … with 4 more variables: median <bch:tm>, `itr/sec` <dbl>,
#> #   mem_alloc <bch:byt>, `gc/sec` <dbl>
```
New:
``` r
bench::mark(
  predictions(mod, variables = list(hp = c(100, 120))),
  predictions(mod, newdata = datagridcf(hp = c(100, 120), cyl = c(4, 6))),
  check = FALSE
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 × 6
#>   expression                                                                 min
#>   <bch:expr>                                                              <bch:>
#> 1 predictions(mod, variables = list(hp = c(100, 120)))                     9.08s
#> 2 predictions(mod, newdata = datagridcf(hp = c(100, 120), cyl = c(4, 6)))  8.23s
#> # … with 4 more variables: median <bch:tm>, `itr/sec` <dbl>,
#> #   mem_alloc <bch:byt>, `gc/sec` <dbl>
```
