### PR TITLE
Misc perf improvements

### DIFF
--- a/R/get_contrast_data.R
+++ b/R/get_contrast_data.R
@@ -109,8 +109,8 @@ get_contrast_data <- function(model,
         lo <- rbindlist(lo, fill = TRUE)
         hi <- rbindlist(hi, fill = TRUE)
         original <- rbindlist(original, fill = TRUE)
-        ter <- unlist(ter)
-        lab <- unlist(lab)
+        ter <- unlist(ter, use.names = FALSE)
+        lab <- unlist(lab, use.names = FALSE)
         lo[, "term" := ter]
         hi[, "term" := ter]
         original[, "term" := ter]

--- a/R/get_contrasts.R
+++ b/R/get_contrasts.R
@@ -229,7 +229,7 @@ get_contrasts <- function(model,
     out[, predicted_hi := pred_hi[["estimate"]]]
 
     if (!is.null(pred_or)) {
-        setDT(pred_or)
+        data.table::setDT(pred_or)
         out[, predicted := pred_or[["estimate"]]]
     } else {
         out[, predicted := NA_real_]

--- a/R/get_contrasts.R
+++ b/R/get_contrasts.R
@@ -229,6 +229,7 @@ get_contrasts <- function(model,
     out[, predicted_hi := pred_hi[["estimate"]]]
 
     if (!is.null(pred_or)) {
+        setDT(pred_or)
         out[, predicted := pred_or[["estimate"]]]
     } else {
         out[, predicted := NA_real_]


### PR DESCRIPTION
Before:
``` r
library(marginaleffects)

tmp <- list()
for (i in 1:30000) {
  tmp[[i]] <- mtcars
}
tmp2 <- data.table::rbindlist(tmp)

mod <- lm(mpg ~ hp + disp + cyl, data = tmp2)

results <- bench::mark(
  out = comparisons(mod, variables = list(hp = c(100, 120), cyl = c(4, 6))),
  iterations = 10
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
results[, c(1, 3, 5)]
#> # A tibble: 1 × 3
#>   expression   median mem_alloc
#>   <bch:expr> <bch:tm> <bch:byt>
#> 1 out           9.68s    7.29GB
```
After:
``` r
results <- bench::mark(
  out = comparisons(mod, variables = list(hp = c(100, 120), cyl = c(4, 6))),
  iterations = 10
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
results[, c(1, 3, 5)]
#> # A tibble: 1 × 3
#>   expression   median mem_alloc
#>   <bch:expr> <bch:tm> <bch:byt>
#> 1 out           7.33s    7.15GB
```

Moderate gain here but I think these `unlist()` lines are called a lot in other functions.

---

FYI I discovered recently that there's a large gain with `use.names = FALSE` if you don't need the names:
``` r
test <- list(
  hp = rep("hp", 1e6),
  cyl = rep("cyl", 1e6),
  drat = rep("drat", 1e6)
)

bench::mark(
  unlist(test),
  unlist(test, use.names = FALSE),
  check = FALSE
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 × 6
#>   expression                           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 unlist(test)                        1.4s     1.4s     0.712    76.8MB     1.42
#> 2 unlist(test, use.names = FALSE)   19.6ms   24.1ms    10.3      22.9MB     4.43
```