### PR TITLE
Small speed improvement

### DIFF
--- a/R/comparisons.R
+++ b/R/comparisons.R
@@ -419,8 +419,8 @@ comparisons <- function(model,
             tmp <- contrast_data$original[, ..idx, drop = FALSE]
             # contrast_data is duplicated to compute contrasts for different terms or pairs
             bycols <- intersect(colnames(tmp), colnames(mfx))
-            idx <- do.call(paste, c(tmp[, ..bycols], sep = "|"))
-            tmp <- tmp[!duplicated(idx), , drop = FALSE]
+            idx <- duplicated(tmp, by = bycols)
+            tmp <- tmp[!idx]
             mfx <- merge(mfx, tmp, all.x = TRUE, by = bycols, sort = FALSE)
         # HACK: relies on NO sorting at ANY point
         } else {
@@ -457,7 +457,7 @@ comparisons <- function(model,
         idx <- c("term", grep("^term$|^contrast$|^contrast_", colnames(mfx), value = TRUE), bycols)
         idx <- intersect(idx, colnames(mfx))
         if (length(idx) > 0) data.table::setorderv(mfx, cols = idx)
-    } 
+    }
 
     stubcols <- c(
         "rowid", "rowidcf", "type", "group", "term", "hypothesis", "by",

--- a/R/sanitize_type.R
+++ b/R/sanitize_type.R
@@ -32,7 +32,7 @@ sanitize_type <- function(model, type, calling_function = NULL) {
     }
 
     # known models are scrutinized tightly
-    if (model_class %in% dict$class) {
+    if (model_class %in% unique(dict$class)) {
         valid <- dict[dict$class == model_class, , drop = FALSE]
         if (!all(type %in% c(valid$base, valid$insight))) {
             msg <- sprintf("The `type` argument for models of class `%s` must be an element of: %s",


### PR DESCRIPTION
Before:
``` r
library(marginaleffects)

# simulate data and fit a large model
N <- 3*1e4
dat <- data.frame(matrix(rnorm(N * 26), ncol = 26))
mod <- lm(X1 ~ ., dat)

bench::mark(
  slopes(mod),
  iterations = 10
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression       min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>  <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 slopes(mod)    17.5s    20.5s    0.0506    23.4GB     1.33
```

After:
``` r
bench::mark(
  slopes(mod),
  iterations = 10
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression       min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>  <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 slopes(mod)    16.4s    18.7s    0.0540    23.3GB     1.88
```
