### PR TITLE
Speed up `complete_levels()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: marginaleffects
 Title: Predictions, Comparisons, Slopes, Marginal Means, and Hypothesis Tests
-Version: 0.9.0.9045
+Version: 0.9.0.9046
 Authors@R: 
     c(person(given = "Vincent",
              family = "Arel-Bundock",

--- a/R/comparisons.R
+++ b/R/comparisons.R
@@ -528,7 +528,7 @@ comparisons <- function(model,
     }
 
     if (!isTRUE(internal_call)) {
-        setDF(out)
+        data.table::setDF(out)
     }
 
     out <- set_marginaleffects_attributes(

--- a/R/complete_levels.R
+++ b/R/complete_levels.R
@@ -31,14 +31,17 @@ complete_levels <- function(x, character_levels = NULL) {
     # create padding
     if (length(vault) > 0) {
         padding <- utils::head(x, 1)
-        setDF(padding) # not sure why, but this is needed
+        setDT(padding)
         for (v in names(vault)) {
             padding[[v]] <- NULL
         }
         fun <- data.table::CJ
         gr <- do.call("fun", vault)
-        padding <- merge(padding, gr, all = TRUE)
-        padding <- padding[, colnames(x)]
+        padding <- cjdt(list(padding, gr))
+        to_keep <- colnames(x)
+        padding[, ..to_keep]
+        setcolorder(padding, to_keep)
+        setDF(padding)
     } else {
         padding <- data.frame()
     }

--- a/R/complete_levels.R
+++ b/R/complete_levels.R
@@ -31,7 +31,7 @@ complete_levels <- function(x, character_levels = NULL) {
     # create padding
     if (length(vault) > 0) {
         padding <- utils::head(x, 1)
-        setDT(padding)
+        data.table::setDT(padding)
         for (v in names(vault)) {
             padding[[v]] <- NULL
         }
@@ -41,7 +41,7 @@ complete_levels <- function(x, character_levels = NULL) {
         to_keep <- colnames(x)
         padding[, ..to_keep]
         setcolorder(padding, to_keep)
-        setDF(padding)
+        data.table::setDF(padding)
     } else {
         padding <- data.frame()
     }

--- a/R/datagrid.R
+++ b/R/datagrid.R
@@ -105,7 +105,7 @@ datagrid <- function(
     }
 
     # better to assume "standard" class as output
-    setDF(out)
+    data.table::setDF(out)
 
     attr(out, "variables_datagrid") <- names(dots)
 
@@ -371,7 +371,7 @@ prep_datagrid <- function(..., model = NULL, newdata = NULL) {
         variables_cluster <- NULL
     }
 
-    setDT(newdata)
+    data.table::setDT(newdata)
     
     attr(newdata, "marginaleffects_variable_class") <- attr_variable_classes
 

--- a/R/get_contrasts.R
+++ b/R/get_contrasts.R
@@ -19,9 +19,9 @@ get_contrasts <- function(model,
     # some predict() methods need data frames and will convert data.tables
     # internally, which can be very expensive if done many times. we do it once
     # here.
-    setDF(lo)
-    setDF(hi)
-    setDF(original)
+    data.table::setDF(lo)
+    data.table::setDF(hi)
+    data.table::setDF(original)
 
     # brms models need to be combined to use a single seed when sample_new_levels="gaussian"
     if (inherits(model, "brmsfit")) {
@@ -95,7 +95,7 @@ get_contrasts <- function(model,
     }
 
     # lots of indexing later requires a data.table
-    setDT(original)
+    data.table::setDT(original)
 
     if (!inherits(pred_hi, "data.frame") || !inherits(pred_lo, "data.frame") || !inherits(pred_or, c("data.frame", "NULL"))) {
         insight::format_error("Unable to compute predicted values with this model. You can try to supply a different dataset to the `newdata` argument. If this does not work, you can file a report on the Github Issue Tracker: https://github.com/vincentarelbundock/marginaleffects/issues")
@@ -103,7 +103,7 @@ get_contrasts <- function(model,
 
     # output data.frame
     out <- pred_lo
-    setDT(out)
+    data.table::setDT(out)
 
     # univariate outcome:
     # original is the "composite" data that we constructed by binding terms and
@@ -144,7 +144,7 @@ get_contrasts <- function(model,
     # by
     if (isTRUE(checkmate::check_data_frame(by))) {
         bycols <- "by"
-        setDT(by)
+        data.table::setDT(by)
         tmp <- setdiff(intersect(colnames(out), colnames(by)), "by")
 
         if (length(tmp) == 0) {
@@ -219,7 +219,7 @@ get_contrasts <- function(model,
         draws_or <- attr(pred_or, "posterior_draws")
     }
     
-    setDT(pred_hi)
+    data.table::setDT(pred_hi)
 
     out[, predicted_lo := pred_lo[["estimate"]]]
     out[, predicted_hi := pred_hi[["estimate"]]]

--- a/R/get_predict.R
+++ b/R/get_predict.R
@@ -83,7 +83,7 @@ get_predict.default <- function(model,
         stop(sprintf("Unable to extract predictions of type %s from a model of class %s. Please report this problem, along with reproducible code and data on Github: https://github.com/vincentarelbundock/marginaleffects/issues", type, class(model)[1]), call. = FALSE)
     }
 
-    setDF(out)
+    data.table::setDF(out)
 
     out <- sort_columns(out, first = c("rowid", "group", "estimate"))
 

--- a/R/methods_gamlss.R
+++ b/R/methods_gamlss.R
@@ -42,7 +42,7 @@ get_predict.gamlss <- function(
   # predict.gamlss() breaks when `newdata` includes unknown variables
   origindata <- insight::get_data(model)
   originvars <- colnames(origindata)
-  setDF(newdata)
+  data.table::setDF(newdata)
   index <- which(colnames(newdata) %in% originvars)
   tmp <- newdata[, index]
   hush(out <- predict_gamlss(model, newdata = tmp, type = type, data = origindata, ...))

--- a/R/methods_ordinal.R
+++ b/R/methods_ordinal.R
@@ -16,7 +16,7 @@ get_predict.clm <- function(model,
     resp <- insight::find_response(model)
 
     # otherwise `predict.clm` does not see some columns (mystery)
-    setDF(newdata)
+    data.table::setDF(newdata)
 
     newdata <- newdata[, setdiff(colnames(newdata), resp), drop = FALSE]
 

--- a/R/posterior_draws.R
+++ b/R/posterior_draws.R
@@ -64,7 +64,7 @@ posterior_draws <- function(x, shape = "long") {
         cols <- unique(c("drawid", "draw", "rowid", colnames(out)))
         cols <- intersect(cols, colnames(out))
         setcolorder(out, cols)
-        setDF(out)
+        data.table::setDF(out)
         return(out)
     }
 

--- a/R/predictions.R
+++ b/R/predictions.R
@@ -566,7 +566,7 @@ get_predictions <- function(model,
     # extract attributes before setDT
     draws <- attr(out, "posterior_draws")
 
-    setDT(out)
+    data.table::setDT(out)
 
     # unpad factors before averaging
     # trust `newdata` rowid more than `out` because sometimes `get_predict()` will add a positive index even on padded data

--- a/R/slopes.R
+++ b/R/slopes.R
@@ -271,7 +271,7 @@ slopes <- function(model,
         internal_call = TRUE,
         ...)
 
-    setDT(out)
+    data.table::setDT(out)
 
     # clean columns
     stubcols <- c("rowid", "type", "group", "term", "contrast", "hypothesis", "dydx", "estimate", "std.error", "statistic", "p.value", "conf.low", "conf.high",
@@ -301,7 +301,7 @@ slopes <- function(model,
     attr(out, "call") <- call_attr
 
     # class
-    setDF(out)
+    data.table::setDF(out)
     class(out) <- setdiff(class(out), "comparisons")
     class(out) <- c("slopes", "marginaleffects", class(out))
     return(out)


### PR DESCRIPTION
Example coming from the [`marginal_means()` vignette](https://vincentarelbundock.github.io/marginaleffects/dev/articles/marginalmeans.html#case-study-multinomial-logit) (just reduced the number in `replicate()`).

Before:
``` r
library(nnet)
library(marginaleffects)

set.seed(1839)
n <- 1200
x <- factor(sample(letters[1:3], n, TRUE))
y <- vector(length = n)
y[x == "a"] <- sample(letters[4:6], sum(x == "a"), TRUE)
y[x == "b"] <- sample(letters[4:6], sum(x == "b"), TRUE, c(1 / 4, 2 / 4, 1 / 4))
y[x == "c"] <- sample(letters[4:6], sum(x == "c"), TRUE, c(1 / 5, 3 / 5, 2 / 5))

dat <- data.frame(x = x, y = factor(y))
tmp <- as.data.frame(replicate(9, factor(sample(letters[7:9], n, TRUE))))
dat <- cbind(dat, tmp)
void <- capture.output({
  mod <- multinom(y ~ ., dat)
})

bench::mark(
  expr = marginal_means(mod,
                        type = "probs",
                        variables = c("x", "V1"),
                        variables_grid = paste0("V", 2:3)),
  iterations = 10
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 expr          25.8s    26.1s    0.0372    13.9GB     7.81
```

After:
``` r
bench::mark(
  expr = marginal_means(mod,
                        type = "probs",
                        variables = c("x", "V1"),
                        variables_grid = paste0("V", 2:3)),
  iterations = 10
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 expr          17.7s    18.6s    0.0533    13.8GB     13.2
```