### PR TITLE
Speed gain in `predictions()` 

### DIFF
--- a/R/predictions.R
+++ b/R/predictions.R
@@ -470,8 +470,8 @@ predictions <- function(model,
             ...)
     }
 
-    out <- data.table(tmp)
-    setDT(newdata)
+    out <- data.table::data.table(tmp)
+    data.table::setDT(newdata)
 
     # expensive: only do this inside jacobian if necessary
     if (!inherits(model, "mclogit")) { # weird case. probably a cleaner way but lazy now...

--- a/R/predictions.R
+++ b/R/predictions.R
@@ -470,7 +470,8 @@ predictions <- function(model,
             ...)
     }
 
-    out <- data.frame(tmp)
+    out <- data.table(tmp)
+    setDT(newdata)
 
     # expensive: only do this inside jacobian if necessary
     if (!inherits(model, "mclogit")) { # weird case. probably a cleaner way but lazy now...
@@ -496,7 +497,7 @@ predictions <- function(model,
         sort(grep("^predicted", colnames(newdata), value = TRUE)))
     cols <- intersect(stubcols, colnames(out))
     cols <- unique(c(cols, colnames(out)))
-    out <- out[, cols, drop = FALSE]
+    out <- out[, ..cols]
 
     attr(out, "posterior_draws") <- draws
 


### PR DESCRIPTION
Example from [this vignette](https://vincentarelbundock.github.io/marginaleffects/articles/predictions.html#multinomial-models).

Before:
``` r
library(nnet)
library(marginaleffects)

mtcars$gear <- factor(mtcars$gear)

tmp <- list()
for (i in 1:10000) tmp[[i]] <- mtcars
dat <- data.table::rbindlist(tmp)

nom <- multinom(gear ~ mpg + am * vs, data = dat, trace = FALSE)

bench::mark(
  predictions(nom, type = "probs"),
  iterations = 10
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression                            min   median `itr/sec` mem_alloc gc/se…¹
#>   <bch:expr>                       <bch:tm> <bch:tm>     <dbl> <bch:byt>   <dbl>
#> 1 predictions(nom, type = "probs")      23s    26.5s    0.0384    3.96GB    1.01
#> # … with abbreviated variable name ¹​`gc/sec`
```

After:
``` r
bench::mark(
  predictions(nom, type = "probs"),
  iterations = 10
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression                            min   median `itr/sec` mem_alloc gc/se…¹
#>   <bch:expr>                       <bch:tm> <bch:tm>     <dbl> <bch:byt>   <dbl>
#> 1 predictions(nom, type = "probs")    17.6s    18.6s    0.0511    3.86GB    1.34
#> # … with abbreviated variable name ¹​`gc/sec`
```
The speed gain is much higher in `reprex()` than in my local session (- 2 sec), not sure how accurate it is (but it should still be a gain anyway)

---

Edit: @vincentarelbundock no idea where the failures come from