### PR TITLE
Small speedup for matrix multiplication

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: marginaleffects
 Title: Predictions, Comparisons, Slopes, Marginal Means, and Hypothesis Tests
-Version: 0.10.0.9012
+Version: 0.10.0.9013
 Authors@R: 
     c(person(given = "Vincent",
              family = "Arel-Bundock",

--- a/R/comparisons.R
+++ b/R/comparisons.R
@@ -271,15 +271,15 @@ comparisons <- function(model,
         df = df),
         list(...))
     call_attr <- do.call("call", call_attr)
-    
+
     # multiple imputation
     if (inherits(model, "mira")) {
         out <- process_imputation(model, call_attr)
         return(out)
     }
-    
+
     # more sanity chekcs
-    
+
     conf_level <- sanitize_conf_level(conf_level, ...)
     sanity_dots(model, ...)
     checkmate::assert_number(eps, lower = 1e-10, null.ok = TRUE)
@@ -310,7 +310,7 @@ comparisons <- function(model,
     } else {
         addvar <- FALSE
     }
-    
+
     # extracting modeldata repeatedly is slow.
     # checking dots allows cheap multiple imputation
     dots <- list(...)
@@ -326,13 +326,13 @@ comparisons <- function(model,
         }
         modeldata <- get_modeldata(model, additional_variables = addvar)
     }
-    
+
     newdata <- sanitize_newdata(
         model = model,
         newdata = newdata,
         by = by,
         modeldata = modeldata)
-    
+
     # weights: before sanitize_variables
     sanity_wts(wts, newdata) # after sanity_newdata
     if (!is.null(wts) && isTRUE(checkmate::check_string(wts))) {
@@ -465,7 +465,7 @@ comparisons <- function(model,
         if ("rowid" %in% colnames(newdata)) {
             idx <- c("rowid", "rowidcf", "term", "contrast", "by", setdiff(colnames(contrast_data$original), colnames(mfx)))
             idx <- intersect(idx, colnames(contrast_data$original))
-            tmp <- contrast_data$original[, ..idx, drop = FALSE]
+            tmp <- contrast_data$original[, ..idx]
             # contrast_data is duplicated to compute contrasts for different terms or pairs
             bycols <- intersect(colnames(tmp), colnames(mfx))
             idx <- duplicated(tmp, by = bycols)

--- a/R/get_se_delta.R
+++ b/R/get_se_delta.R
@@ -114,7 +114,7 @@ get_se_delta <- function(model,
     # Var(dydx) = J Var(beta) J'
     # computing the full matrix is memory-expensive, and we only need the diagonal
     # algebra trick: https://stackoverflow.com/a/42569902/342331
-    se <- sqrt(colSums(t(J %*% V) * t(J)))
+    se <- sqrt(colSums(t(crossprod(t(J), V)) * t(J)))
     se[se == 0] <- NA_real_
     attr(se, "jacobian") <- J
 


### PR DESCRIPTION
From [this SO answer](https://stackoverflow.com/questions/35923787/fast-large-matrix-multiplication-in-r):
``` r
n_cols = 30

my_J = matrix(sample(1:50, n_cols * 2500000, TRUE), ncol = n_cols)
my_V = matrix(sample(1:10, n_cols^2, TRUE), ncol = n_cols)

bench::mark(
  my_J %*% my_V,
  crossprod(t(my_J), my_V),
  iterations = 10
)
#> # A tibble: 2 × 6
#>   expression                    min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>               <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 my_J %*% my_V               3.35s    3.35s     0.299    1.12GB     2.99
#> 2 crossprod(t(my_J), my_V)    2.08s    2.08s     0.481     1.4GB     5.29
```

Doesn't really make sense to benchmark with `marginaleffects` functions since it's a small change in the total time

---

Besides this, I'm seeing `data.table` warnings in the tests (even before this change) but I don't know where they come from.
```
1: In data.table::setDT(modeldata) :
  Some columns are a multi-column type (such as a matrix column): [3]. setDT will retain 
these columns as-is but subsequent operations like grouping and joining may fail. Please
 consider as.data.table() instead which will create a new column for each embedded column.
```