### PR TITLE
Multiple Imputation Modifications: Return pooled model + improve documentation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # marginaleffects 0.11.1.9000
 
-* When processing objects obtained using `mice` multiple imputation, a list of models is attached to the `model` attribute of the output. This means that we can extract all individual models using `attr(mfx, "model")`, and that functions like `modelsummary::modelsummary()` will not erroneously report goodness-of-fit statistics from just a single model.
+* When processing objects obtained using `mice` multiple imputation, the pooled model using `mice::pool` is attached to the `model` attribute of the output. This means that functions like `modelsummary::modelsummary()` will not erroneously report goodness-of-fit statistics from just a single model and will instead appropriately report the statistics for the pooled model.
 
 # marginaleffects 0.11.1
 

--- a/R/imputation.R
+++ b/R/imputation.R
@@ -30,7 +30,7 @@ process_imputation <- function(x, call_attr) {
         conf_level = call_attr[["conf_level"]],
         df = mipool$pooled$df)
     attr(out, "inferences") <- mipool
-    attr(out, "model") <- lapply(mfx_list, attr, "model")
+    attr(out, "model") <- lapply(mfx_list, attr, "model") |> mice::pool()
     return(out)
 }
 

--- a/R/imputation.R
+++ b/R/imputation.R
@@ -30,7 +30,7 @@ process_imputation <- function(x, call_attr) {
         conf_level = call_attr[["conf_level"]],
         df = mipool$pooled$df)
     attr(out, "inferences") <- mipool
-    attr(out, "model") <- lapply(mfx_list, attr, "model") |> mice::pool()
+    attr(out, "model") <- mice::pool(lapply(mfx_list, attr, "model"))
     return(out)
 }
 

--- a/vignettes/multiple_imputation.Rmd
+++ b/vignettes/multiple_imputation.Rmd
@@ -126,11 +126,11 @@ modelsummary(models, shape = term : contrast + Species ~ model)
 ```
 
 
-# Weights and `by`: Accessing variables from the original dataset
+# Passing new data arguments: `newdata`, `wts`, `by`, etc.
 
-Sometimes, we want to access variables from the original dataset to use as weights in the `wts` argument or as averaging category in the `by` argument. For some models, it can be challenging to preserve the full original data including all its columns, throughout the pipeline, from `mice`, to `lapply`, to `marginaleffects`. For example, some modeling packages do not store the original data in the model object, so `marginaleffects` has to try to retrieve it by name from the global environment, which may be impossible when estimating models in a loop or using `lapply`-style functional programming.
+Sometimes we want to pass arguments changing or specifying the data on which we will do our analysis using `marginaleffects`. This can be for reasons such as wanting to specify the values or weights at which we evaluate e.g. `avg_slopes`, or due to the underlying models not robustly preserving all the original data columns (such as `fixest` objects not saving their data in the fit object making it potentially challenging to retrieve, and even if retrievable it will not include the weights used during fitting as a column as `wts` expects when given a string).
 
-In those cases, it can be useful to revert to a more manual (but still very easy) approach. Here is an example using the `wts` argument and `fixest` models:
+If we are not using multiple imputation, or if we want to just pass a single dataset to the several fitted models after multiple imputation, we can pass a single dataset to the `newdata` argument. However, if we wish to supply each model in our list resulting after multiple imputation with a /different/ dataset on which to calculate results, we cannot use `newdata`. Instead, in this case it can be useful to revert to a more manual (but still very easy) approach. Here is an example calculating `avg_slopes` using a different set of weights for each of the `fixest` models which we fit after multiple imputation.
 
 ```{r}
 set.seed(1024)


### PR DESCRIPTION
See commit messages for further details. This follows on issue  #739 
Two commits:
1. Return pooled model in `attr(mfx, "model")` after multiple imputation. This means that other tools such as `modelsummary` will find the appropriate summary statistics for the pooled model which it shows the values for.
2.  Modify multiple imputation vignette to try and clarify the generality of the use of the alternate slightly more manual workflow.