### PR TITLE
Some speed gain for `inferences()`

### DIFF
--- a/R/recall.R
+++ b/R/recall.R
@@ -21,7 +21,7 @@ recall <- function(x, ...) {
 
     # unsupported call: return `NULL`
     } else {
-        if (!as.character(x)[1] %in% funs) {
+        if (!as.character(x[1]) %in% funs) {
             return(NULL)
         }
         mc <- x


### PR DESCRIPTION
I was looking a bit at #761 and I noticed a tiny thing that slows down `inferences()`. Basically it's much faster to extract the function name first and then convert it as character than converting the whole call as character and then extract the function name.

This speed gain is important with 1) larger data (meaning a few thousands obs) and 2) few repetitions in the bootstrap (otherwise most of the time is spent on running the bootstrap itself):

``` r
library(dplyr, warn.conflicts = FALSE)
library(marginaleffects)

big_mtcars <- mtcars %>% 
  sample_n(15000, replace = TRUE)

mod <- lm(mpg ~ .,data=big_mtcars)
foo <- avg_predictions(mod) 

### Before
bench::mark(
  test = inferences(foo, method="boot", R = 5)
)
#> Warning in norm.inter(t, alpha): extreme order statistics used as endpoints

#> Warning in norm.inter(t, alpha): extreme order statistics used as endpoints
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 test          11.2s    11.2s    0.0890    1.02GB     1.42

### After
bench::mark(
  test = inferences(foo, method="boot", R = 5)
)
#> Warning in norm.inter(t, alpha): extreme order statistics used as endpoints

#> Warning in norm.inter(t, alpha): extreme order statistics used as endpoints
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 test          5.31s    5.31s     0.188    1.01GB     3.58
```