### PR TITLE
Large speed improvement for `inferences()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: marginaleffects
 Title: Predictions, Comparisons, Slopes, Marginal Means, and Hypothesis Tests
-Version: 0.11.1.9012
+Version: 0.11.1.9013
 Authors@R: 
     c(person(given = "Vincent",
              family = "Arel-Bundock",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,14 @@
-# marginaleffects 0.11.1.9001
+# marginaleffects 0.11.1.9003
 
 * Strings in `wts` are accepted with the `by` argument.
 * `predictions()` and `avg_predictions()` no longer use an automatic backtransformation for GLM models unless `hypothesis` is `NULL`.
 * `vcov()` can be used to retrieve a full variance-covariance matrix from objects produced by `comparisons()`, `slopes()`, `predictions()`, or `marginal_means()` objects.
 * When processing objects obtained using `mice` multiple imputation, the pooled model using `mice::pool` is attached to the `model` attribute of the output. This means that functions like `modelsummary::modelsummary()` will not erroneously report goodness-of-fit statistics from just a single model and will instead appropriately report the statistics for the pooled model. Thanks to @Tristan-Siegfried for PR #740.
 * More informative error messages on some prediction problems. Thanks to @andymilne for Report #751.
+
+Performance:
+
+* `inferences()` is now up to 17x faster and much more memory-efficient when `method` is `"boot"` or `"rsample"` (#770, #771, @etiennebacher).
 
 Bugs:
 

--- a/R/bootstrap_boot.R
+++ b/R/bootstrap_boot.R
@@ -29,7 +29,7 @@ bootstrap_boot <- function(model, FUN, ...) {
         modcall[["data"]] <- d
         modboot <- eval(modcall)
         modboot <- eval(modboot)
-        args <- c(list(modboot), dots)
+        args <- c(list(modboot, modeldata = d), dots)
         out <- do.call(FUN, args)$estimate
         return(out)
     }

--- a/R/bootstrap_rsample.R
+++ b/R/bootstrap_rsample.R
@@ -35,7 +35,7 @@ bootstrap_rsample <- function(model, FUN, ...) {
         modcall[["data"]] <- data
         modboot <- eval(modcall)
         modboot <- eval(modboot)
-        args <- c(list(modboot), dots)
+        args <- c(list(modboot, modeldata = data$data), dots)
         out <- do.call(FUN, args)
         out <- tidy(out)
         # `rsample` averages by `term` columns; we don't use it anyway and assume things line up

--- a/inst/tinytest/test-inferences.R
+++ b/inst/tinytest/test-inferences.R
@@ -17,22 +17,27 @@ expect_inherits(x, "matrix")
 
 
 # {boot}
+set.seed(1234)
 x <- mod |> avg_predictions() |> inferences(method = "boot", R = R)
 expect_inherits(x, "predictions")
 expect_equivalent(nrow(x), 1)
+expect_equal(x$std.error, 0.0491, tolerance = 1e-3)
 
 
 # head works
+set.seed(1234)
 x <- mod |> slopes() |> inferences(method = "boot", R = R)
 expect_inherits(head(x), "slopes")
 expect_equivalent(nrow(x), 300)
 expect_equivalent(nrow(head(x)), 6)
-
+expect_equal(x$std.error[1:3], c(0.2425, 0.2824, 0.2626), tolerance = 1e-3)
 
 # avg_ works
+set.seed(1234)
 x <- mod |> avg_slopes() |> inferences(method = "boot", R = R)
 expect_inherits(x, "slopes")
 expect_equivalent(nrow(x), 2)
+expect_equal(x$std.error, c(0.0657, 0.1536), tolerance = 1e-3)
 
 
 x <- mod |> predictions(vcov = "HC3") |> inferences(method = "boot", R = R) |> head()
@@ -50,7 +55,9 @@ expect_equivalent(nrow(x), 2 * R)
 
 
 # {rsample}
+set.seed(1234)
 x <- mod |> avg_predictions() |> inferences(method = "rsample", R = R)
+expect_equal(x$conf.low, 3.6692, tolerance = 1e-3)
 expect_inherits(x, "predictions")
 x <- mod |> slopes() |> inferences(method = "rsample", R = R) |> head()
 expect_inherits(x, "slopes")
@@ -69,10 +76,12 @@ x <- mod |>
 expect_equivalent(nrow(x), 2 * R)
 
 # fwb no validity check
+set.seed(1234)
 x <- mod |> 
      comparisons() |> 
      inferences(method = "fwb", R = R)
 expect_equivalent(nrow(x), 300)
+expect_equal(x$std.error[1:3], c(0.0739, 0.0568, 0.0508), tolerance = 1e-3)
 x <- mod |> 
      avg_comparisons() |> 
      inferences(method = "fwb", R = R)


### PR DESCRIPTION
Related to #761. The bootstrap is slow because it calls `get_modeldata()` a lot inside `predictions()`, which is `FUN` in these lines:

https://github.com/vincentarelbundock/marginaleffects/blob/274d9195ecc48a3430de76562187c0ddbe89687c/R/bootstrap_rsample.R#L34-L44 

What I'm thinking is that you already know the model data, it's the line `modcall[["data"]] <- data`. So you could pass this data directly to `predictions()` and avoid running `get_modeldata()`. 

This leads to very large performance gains:

``` r
library(dplyr, warn.conflicts = FALSE)
library(marginaleffects)

set.seed(1234)
big_mtcars <- mtcars %>% 
  sample_n(15000, replace = TRUE)

mod <- lm(mpg ~ .,data=big_mtcars)
foo <- avg_predictions(mod) 

### Before
bench::mark(
  test = inferences(foo, method="rsample", R = 30)
)
#> Warning: Recommend at least 1000 non-missing bootstrap resamples for term `1`.
#> Recommend at least 1000 non-missing bootstrap resamples for term `1`.
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 test          33.2s    33.2s    0.0301    5.25GB     1.02

### After
bench::mark(
  test = inferences(foo, method="rsample", R = 30)
)
#> Warning: Recommend at least 1000 non-missing bootstrap resamples for term `1`.
#> Recommend at least 1000 non-missing bootstrap resamples for term `1`.
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 test          6.48s    6.48s     0.154     830MB     1.54
```

However, there are no numerical tests (only checks for class of `inferences()` output). I did a few quick checks but these are not comprehensive.

Also, I was limited in time so I just made this for `rsample` but it should be similar for the others (+ I'd like to be sure this is fine before I spend time on the rest).

It is still surprising that it takes several seconds for just 30 reps and 15,000 obs.