### PR TITLE
Performance improvement for elasticities

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# marginaleffects (development version)
+
+Performance:
+
+* Computing elasticities for linear models is now up to 30% faster (#787, @etiennebacher).
+
 # marginaleffects 0.12.0
 
 Breaking change:

--- a/R/get_contrasts.R
+++ b/R/get_contrasts.R
@@ -195,22 +195,19 @@ get_contrasts <- function(model,
     elasticities <- lapply(elasticities, function(x) x$name)
     if (length(elasticities) > 0) {
         split_out <- split(out, by = "term")
-        if (!is.null(original)) {
-            idx1 <- c(v, "rowid", "rowidcf", "term", "group", grep("^contrast", colnames(original), value = TRUE))
-            idx1 <- intersect(idx1, colnames(original))
-            idx1 <- original[, ..idx1]
-            setnames(idx1, old = v, new = "elast")
-        }
-
         for (v in names(elasticities)) {
             idx2 <- unique(c("rowid", "term", "group", by, grep("^contrast", colnames(out), value = TRUE)))
             idx2 <- intersect(idx2, colnames(out))
             # discard other terms to get right length vector
             idx2 <- split_out[[v]][, ..idx2]
             # original is NULL when cross=TRUE
-            if (!is.null(idx1)) {
+            if (!is.null(original)) {
+                idx1 <- c(v, "rowid", "rowidcf", "term", "group", grep("^contrast", colnames(original), value = TRUE))
+                idx1 <- intersect(idx1, colnames(original))
+                idx1 <- original[, ..idx1]
+                setnames(idx1, old = v, new = "elast")
                 on_cols <- intersect(colnames(idx1), colnames(idx2))
-                unique(idx2[idx1, elast := elast, on = on_cols])
+                idx2 <- unique(merge(idx2, idx1, by = on_cols)[, elast := elast])
             }
             elasticities[[v]] <- idx2$elast
         }

--- a/R/get_contrasts.R
+++ b/R/get_contrasts.R
@@ -195,19 +195,22 @@ get_contrasts <- function(model,
     elasticities <- lapply(elasticities, function(x) x$name)
     if (length(elasticities) > 0) {
         split_out <- split(out, by = "term")
+        if (!is.null(original)) {
+            idx1 <- c(v, "rowid", "rowidcf", "term", "group", grep("^contrast", colnames(original), value = TRUE))
+            idx1 <- intersect(idx1, colnames(original))
+            idx1 <- original[, ..idx1]
+            setnames(idx1, old = v, new = "elast")
+        }
+
         for (v in names(elasticities)) {
             idx2 <- unique(c("rowid", "term", "group", by, grep("^contrast", colnames(out), value = TRUE)))
             idx2 <- intersect(idx2, colnames(out))
             # discard other terms to get right length vector
             idx2 <- split_out[[v]][, ..idx2]
             # original is NULL when cross=TRUE
-            if (!is.null(original)) {
-                idx1 <- c(v, "rowid", "rowidcf", "term", "group", grep("^contrast", colnames(original), value = TRUE))
-                idx1 <- intersect(idx1, colnames(original))
-                idx1 <- original[, ..idx1]
-                setnames(idx1, old = v, new = "elast")
+            if (!is.null(idx1)) {
                 on_cols <- intersect(colnames(idx1), colnames(idx2))
-                idx2[, elast := unique(idx1[["elast"]])]
+                unique(idx2[idx1, elast := elast, on = on_cols])
             }
             elasticities[[v]] <- idx2$elast
         }

--- a/R/get_contrasts.R
+++ b/R/get_contrasts.R
@@ -194,17 +194,30 @@ get_contrasts <- function(model,
         variables)
     elasticities <- lapply(elasticities, function(x) x$name)
     if (length(elasticities) > 0) {
-        split_out <- split(out, by = "term")
+        # assigning a subset of "original" to "idx1" takes time and memory
+        # better to do this here for most columns and add the "v" column only
+        # in the loop
+        if (!is.null(original)) {
+            idx1 <- c("rowid", "rowidcf", "term", "group", grep("^contrast", colnames(original), value = TRUE))
+            idx1 <- intersect(idx1, colnames(original))
+            idx1 <- original[, ..idx1]
+        }
+
         for (v in names(elasticities)) {
             idx2 <- unique(c("rowid", "term", "group", by, grep("^contrast", colnames(out), value = TRUE)))
             idx2 <- intersect(idx2, colnames(out))
             # discard other terms to get right length vector
-            idx2 <- split_out[[v]][, ..idx2]
+            idx2 <- out[term == v, ..idx2]
             # original is NULL when cross=TRUE
             if (!is.null(original)) {
-                idx1 <- c(v, "rowid", "rowidcf", "term", "group", grep("^contrast", colnames(original), value = TRUE))
-                idx1 <- intersect(idx1, colnames(original))
-                idx1 <- original[, ..idx1]
+                # if not first iteration, need to remove previous "v" and "elast"
+                if (v %in% colnames(idx1)) {
+                    idx1[, (v) := NULL]
+                }
+                if ("elast" %in% colnames(idx1)) {
+                    idx1[, elast := NULL]
+                }
+                idx1[, (v) := original[[v]]]
                 setnames(idx1, old = v, new = "elast")
                 on_cols <- intersect(colnames(idx1), colnames(idx2))
                 idx2 <- unique(merge(idx2, idx1, by = on_cols)[, elast := elast])


### PR DESCRIPTION
It's a bit more efficient to split a data.table and then call a specific element in the loop rather than filtering the whole data.table at each iteration.

Most of the improvement comes from the change to `merge()`, but I really can't tell why it's more efficient, it just seems to be.

### Benchmarks
(I changed a bit my way of benchmarking, now all results are in the table at the end)

```r
library(bench)

# run same benchmark both on 'main' and on my fork
# https://github.com/DavisVaughan/cross
out <- cross::run(
  pkgs = c("vincentarelbundock/marginaleffects", 
           "etiennebacher/marginaleffects@speedup-elasticities"),
  ~ {
    library(marginaleffects)
    
    # 30,000 obs, 23 predictors
    N <- 30000
    dat <- data.frame(matrix(rnorm(N * 24), ncol = 24))
    mod <- lm(X1 ~ ., dat)
    
    bench::mark(
      avg_slopes(mod, slope = "eydx"), 
      avg_slopes(mod, slope = "dydx"), 
      avg_slopes(mod, slope = "eyex"), 
      check = FALSE,
      iterations = 10
    )
  }
)

tidyr::unnest(out, result) |> 
  dplyr::select(pkg, expression, min, median, mem_alloc) |> 
  dplyr::mutate(pkg = ifelse(grepl("vinc", pkg), "main", "fork")) |> 
  dplyr::arrange(expression)
#> # A tibble: 6 × 5
#>   pkg   expression                               min   median mem_alloc
#>   <chr> <bch:expr>                          <bch:tm> <bch:tm> <bch:byt>
#> 1 main  "avg_slopes(mod, slope = \"eydx\")"   34.75s   41.69s    29.5GB
#> 2 fork  "avg_slopes(mod, slope = \"eydx\")"   25.37s    26.9s   21.84GB
#> 3 main  "avg_slopes(mod, slope = \"dydx\")"    4.79s    4.93s    6.05GB
#> 4 fork  "avg_slopes(mod, slope = \"dydx\")"    4.32s     4.6s    6.05GB
#> 5 main  "avg_slopes(mod, slope = \"eyex\")"   32.83s   34.62s   29.62GB
#> 6 fork  "avg_slopes(mod, slope = \"eyex\")"   24.08s   24.81s   21.96GB
```