### PR TITLE
Speedup `marginalmeans()`

### DIFF
--- a/R/get_modeldata.R
+++ b/R/get_modeldata.R
@@ -104,7 +104,7 @@ set_variable_class <- function(modeldata, model = NULL) {
             cl[col] <- "other"
         } else if (is.numeric(out[[col]])) {
             # faster than all(out[[col]] %in% 0:1)
-            if (isTRUE(!any(foo != 0 | foo != 1))) {
+            if (isTRUE(!any(out[[col]] != 0 | out[[col]] != 1))) {
                 cl[col] <- "binary"
             } else {
                 cl[col] <- "numeric"

--- a/R/get_modeldata.R
+++ b/R/get_modeldata.R
@@ -106,7 +106,7 @@ set_variable_class <- function(modeldata, model = NULL) {
             # more performant in time and memory than all(out[[col]] %in% 0:1)
             if (isTRUE(min(out[[col]]) == 0 &&
                        max(out[[col]]) == 1 &&
-                       length(unique(out[[col]])) == 2)) {
+                       data.table::uniqueN(out[[col]]) == 2)) {
                 cl[col] <- "binary"
             } else {
                 cl[col] <- "numeric"

--- a/R/get_modeldata.R
+++ b/R/get_modeldata.R
@@ -104,9 +104,9 @@ set_variable_class <- function(modeldata, model = NULL) {
             cl[col] <- "other"
         } else if (is.numeric(out[[col]])) {
             # more performant in time and memory than all(out[[col]] %in% 0:1)
-            if (min(out[[col]]) == 0 &&
-                max(out[[col]]) == 1 &&
-                length(unique(out[[col]])) == 2) {
+            if (isTRUE(min(out[[col]]) == 0 &&
+                       max(out[[col]]) == 1 &&
+                       length(unique(out[[col]])) == 2)) {
                 cl[col] <- "binary"
             } else {
                 cl[col] <- "numeric"

--- a/R/get_modeldata.R
+++ b/R/get_modeldata.R
@@ -103,8 +103,10 @@ set_variable_class <- function(modeldata, model = NULL) {
         } else if (inherits(out[[col]], "Surv")) { # is numeric but breaks the %in% 0:1 check
             cl[col] <- "other"
         } else if (is.numeric(out[[col]])) {
-            # faster than all(out[[col]] %in% 0:1)
-            if (isTRUE(!any(out[[col]] != 0 | out[[col]] != 1))) {
+            # more performant in time and memory than all(out[[col]] %in% 0:1)
+            if (min(out[[col]]) == 0 &&
+                max(out[[col]]) == 1 &&
+                length(unique(out[[col]])) == 2) {
                 cl[col] <- "binary"
             } else {
                 cl[col] <- "numeric"

--- a/R/get_modeldata.R
+++ b/R/get_modeldata.R
@@ -79,7 +79,7 @@ get_modeldata <- function(model, additional_variables = FALSE, modeldata = NULL,
 set_variable_class <- function(modeldata, model = NULL) {
 
     if (is.null(modeldata)) return(modeldata)
-    
+
     # this can be costly on large datasets, when only a portion of
     # variables are used in the model
     variables <- NULL
@@ -103,7 +103,8 @@ set_variable_class <- function(modeldata, model = NULL) {
         } else if (inherits(out[[col]], "Surv")) { # is numeric but breaks the %in% 0:1 check
             cl[col] <- "other"
         } else if (is.numeric(out[[col]])) {
-            if (isTRUE(all(out[[col]] %in% 0:1))) {
+            # faster than all(out[[col]] %in% 0:1)
+            if (isTRUE(!any(foo != 0 | foo != 1))) {
                 cl[col] <- "binary"
             } else {
                 cl[col] <- "numeric"
@@ -112,7 +113,7 @@ set_variable_class <- function(modeldata, model = NULL) {
             cl[col] <- "other"
         }
     }
-    
+
     if (is.null(model)) {
         attr(out, "marginaleffects_variable_class") <- cl
         return(out)


### PR DESCRIPTION
Another small memory and speed improvement, for `marginal_means()` this time. If I’m not mistaken, `all(x %in% 0:1)` needs first to evaluate the condition for all values of `x`, which is wasting time.

``` r
library(bench)

out <- cross::run(
  pkgs = c("vincentarelbundock/marginaleffects",
           "etiennebacher/marginaleffects@speedup-marginalmeans"), 
  ~{
    library(marginaleffects)
    library(data.table)
    dat <- mtcars
    dat$cyl <- as.factor(dat$cyl)
    dat$am <- as.logical(dat$am)
    dat$carb <- as.factor(dat$carb)
    dat2 <- rbindlist(rep(list(dat), 50000))
    mod <- lm(mpg ~ hp + cyl + am + carb + qsec + disp, data = dat2)
    
    bench::mark(
      marginal_means(mod),
      check = FALSE,
      iterations = 10
    ) 
  }
)

tidyr::unnest(out, result) |>
  dplyr::select(pkg, median, mem_alloc) |> 
  dplyr::mutate(pkg = ifelse(grepl("vincent", pkg), "main", "fork"))
#> # A tibble: 2 × 3
#>   pkg     median mem_alloc
#>   <chr> <bch:tm> <bch:byt>
#> 1 main     10.2s    7.41GB
#> 2 fork     3.71s    3.21GB
```

I put below various benchmarks I tried for alternatives to `all(x %in% 0:1)`, if anyone finds this interesting (and also so I keep this somewhere).

<details>
<summary> Benchmarks </summary>

``` r
### all 0 and 1
foo <- sample(0:1, 1e7, TRUE)
bench::mark(
  all(foo %in% 0:1),
  !anyNA(match(foo, 0:1, nomatch = NA)),
  !any(foo != 0 & foo != 1),
  identical(range(foo), 0:1) && data.table::uniqueN(foo, by = NULL) == 2,
  min(foo) == 0 && max(foo) == 1 && data.table::uniqueN(foo, by = NULL) == 2,
  iterations = 10
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 5 × 6
#>   expression                            min  median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                        <bch:t> <bch:t>     <dbl> <bch:byt>    <dbl>
#> 1 all(foo %in% 0:1)                  75.6ms 103.2ms      8.84   114.4MB    10.6 
#> 2 !anyNA(match(foo, 0:1, nomatch =…  55.9ms  68.4ms     13.2     76.3MB     7.93
#> 3 !any(foo != 0 & foo != 1)         120.2ms 168.2ms      5.78   114.4MB     6.93
#> 4 identical(range(foo), 0:1) && da…  92.1ms 112.9ms      8.92      78MB     6.24
#> 5 min(foo) == 0 && max(foo) == 1 &…  60.1ms  68.3ms     14.5     38.1MB     4.34

### not all 0 and 1
foo <- sample(0:20, 1e7, TRUE)
bench::mark(
  all(foo %in% 0:1),
  !anyNA(match(foo, 0:1, nomatch = NA)),
  !any(foo != 0 & foo != 1),
  identical(range(foo), 0:1) && data.table::uniqueN(foo, by = NULL) == 2,
  min(foo) == 0 && max(foo) == 1 && data.table::uniqueN(foo, by = NULL) == 2,
  iterations = 10
)
#> # A tibble: 5 × 6
#>   expression                            min  median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                        <bch:t> <bch:t>     <dbl> <bch:byt>    <dbl>
#> 1 all(foo %in% 0:1)                 113.8ms 122.6ms      8.16   114.4MB    40.8 
#> 2 !anyNA(match(foo, 0:1, nomatch =…   100ms 126.4ms      8.49    76.3MB    19.8 
#> 3 !any(foo != 0 & foo != 1)         101.7ms 101.7ms      9.83   114.4MB    88.5 
#> 4 identical(range(foo), 0:1) && da…  35.3ms  45.4ms     21.6     38.1MB     5.39
#> 5 min(foo) == 0 && max(foo) == 1 &…    12ms  17.4ms     57.1         0B     0
```

</details>
