### PR TITLE
Allowing `wts = TRUE` to extract weights from model using `insight::get_weights()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: marginaleffects
 Title: Predictions, Comparisons, Slopes, Marginal Means, and Hypothesis Tests
-Version: 0.18.0.9003
+Version: 0.18.0.9004
 Authors@R: 
     c(person(given = "Vincent",
              family = "Arel-Bundock",

--- a/R/slopes.R
+++ b/R/slopes.R
@@ -46,7 +46,7 @@
 #'    - Other: `"NeweyWest"`, `"KernHAC"`, `"OPG"`. See the `sandwich` package documentation.
 #'  * One-sided formula which indicates the name of cluster variables (e.g., `~unit_id`). This formula is passed to the `cluster` argument of the `sandwich::vcovCL` function.
 #'  * Square covariance matrix
-#'  * Function which returns a covariance matrix (e.g., `stats::vcov(model)`)
+#'  * Function which returns a covariance matrix (e.g., `stats::vcov`)
 #' @param conf_level numeric value between 0 and 1. Confidence level to use to build a confidence interval.
 #' @param type string indicates the type (scale) of the predictions used to
 #' compute contrasts or slopes. This can differ based on the model
@@ -60,7 +60,8 @@
 #' - "eydx": dY/dX * Y
 #' - "dyex": dY/dX / X
 #' - Y is the predicted value of the outcome; X is the observed value of the predictor.
-#' @param wts string or numeric: weights to use when computing average contrasts or slopes. These weights only affect the averaging in `avg_*()` or with the `by` argument, and not the unit-level estimates themselves. Internally, estimates and weights are passed to the `weighted.mean()` function.
+#' @param wts logical, string, or numeric: weights to use when computing average contrasts or slopes. These weights only affect the averaging in `avg_*()` or with the `by` argument, and not the unit-level estimates themselves. Internally, estimates and weights are passed to the `weighted.mean()` function.
+#' + logical: if `TRUE`, weights will be extracted from the supplied model using [insight::get_weights()]. Only allowed when `newdata` is not specified.
 #' + string: column name of the weights variable in `newdata`. When supplying a column name to `wts`, it is recommended to supply the original data (including the weights variable) explicitly to `newdata`.
 #' + numeric: vector of length equal to the number of rows in the original data or in `newdata` (if supplied).
 #' @param hypothesis specify a hypothesis test or custom contrast using a numeric value, vector, or matrix, a string, a string formula, or a function.
@@ -200,7 +201,7 @@
 #'     mod,
 #'     newdata = "mean",
 #'     hypothesis = lc)
-#' 
+#'
 #' @export
 slopes <- function(model,
                    newdata = NULL,

--- a/inst/tinytest/test-weights.R
+++ b/inst/tinytest/test-weights.R
@@ -40,6 +40,14 @@ cmp1 <- comparisons(fit, variables = "treat", wts = "w")
 cmp2 <- comparisons(fit, variables = "treat", wts = "w", comparison = "differenceavg")
 expect_equivalent(cmp2$estimate, weighted.mean(cmp1$estimate, k$w))
 
+# wts = TRUE correctly extracts weights
+a1 <- avg_comparisons(fit, variables = "treat", wts = "w")
+a2 <- avg_comparisons(fit, variables = "treat", wts = TRUE)
+expect_equivalent(a1, a2)
+
+a1 <- avg_comparisons(fit, variables = "treat", by = "married", wts = k$w)
+a2 <- avg_comparisons(fit, variables = "treat", by = "married", wts = TRUE)
+expect_equivalent(a1, a2)
 
 # sanity check
 expect_error(comparisons(mod, wts = "junk"), pattern = "explicitly")
@@ -84,7 +92,7 @@ cmp1 <- avg_comparisons(fit,
     newdata = tmp,
     comparison = "lnratioavg",
     transform = exp)
-cmp2 <- predictions(fit, variables = list(g = c("Control", "Z"))) |> 
+cmp2 <- predictions(fit, variables = list(g = c("Control", "Z"))) |>
     dplyr::group_by(g) |>
     dplyr::summarise(estimate = weighted.mean(estimate, N)) |>
     as.data.frame()
@@ -179,11 +187,11 @@ expect_true(all(cmp1$estimate != cmp2$estimate))
 
 # . logit am mpg [pw=weights]
 #
-# Iteration 0:   log pseudolikelihood = -365.96656  
-# Iteration 1:   log pseudolikelihood = -255.02961  
-# Iteration 2:   log pseudolikelihood = -253.55843  
-# Iteration 3:   log pseudolikelihood = -253.55251  
-# Iteration 4:   log pseudolikelihood = -253.55251  
+# Iteration 0:   log pseudolikelihood = -365.96656
+# Iteration 1:   log pseudolikelihood = -255.02961
+# Iteration 2:   log pseudolikelihood = -253.55843
+# Iteration 3:   log pseudolikelihood = -253.55251
+# Iteration 4:   log pseudolikelihood = -253.55251
 #
 # Logistic regression                                     Number of obs =     32
 #                                                         Wald chi2(1)  =   8.75

--- a/man/comparisons.Rd
+++ b/man/comparisons.Rd
@@ -149,7 +149,7 @@ first entry in the error message is used by default.}
 }
 \item One-sided formula which indicates the name of cluster variables (e.g., \code{~unit_id}). This formula is passed to the \code{cluster} argument of the \code{sandwich::vcovCL} function.
 \item Square covariance matrix
-\item Function which returns a covariance matrix (e.g., \code{stats::vcov(model)})
+\item Function which returns a covariance matrix (e.g., \code{stats::vcov})
 }}
 
 \item{by}{Aggregate unit-level estimates (aka, marginalize, average over). Valid inputs:
@@ -171,8 +171,9 @@ first entry in the error message is used by default.}
 \item \code{TRUE}: Contrasts represent the changes in adjusted predictions when all the predictors specified in the \code{variables} argument are manipulated simultaneously (a "cross-contrast").
 }}
 
-\item{wts}{string or numeric: weights to use when computing average contrasts or slopes. These weights only affect the averaging in \verb{avg_*()} or with the \code{by} argument, and not the unit-level estimates themselves. Internally, estimates and weights are passed to the \code{weighted.mean()} function.
+\item{wts}{logical, string, or numeric: weights to use when computing average contrasts or slopes. These weights only affect the averaging in \verb{avg_*()} or with the \code{by} argument, and not the unit-level estimates themselves. Internally, estimates and weights are passed to the \code{weighted.mean()} function.
 \itemize{
+\item logical: if \code{TRUE}, weights will be extracted from the supplied model using \code{\link[insight:get_weights]{insight::get_weights()}}. Only allowed when \code{newdata} is not specified.
 \item string: column name of the weights variable in \code{newdata}. When supplying a column name to \code{wts}, it is recommended to supply the original data (including the weights variable) explicitly to \code{newdata}.
 \item numeric: vector of length equal to the number of rows in the original data or in \code{newdata} (if supplied).
 }}

--- a/man/get_vcov.Rd
+++ b/man/get_vcov.Rd
@@ -83,7 +83,7 @@ arguments.}
 }
 \item One-sided formula which indicates the name of cluster variables (e.g., \code{~unit_id}). This formula is passed to the \code{cluster} argument of the \code{sandwich::vcovCL} function.
 \item Square covariance matrix
-\item Function which returns a covariance matrix (e.g., \code{stats::vcov(model)})
+\item Function which returns a covariance matrix (e.g., \code{stats::vcov})
 }}
 
 \item{type}{string indicates the type (scale) of the predictions used to

--- a/man/hypotheses.Rd
+++ b/man/hypotheses.Rd
@@ -65,7 +65,7 @@ hypotheses(
 }
 \item One-sided formula which indicates the name of cluster variables (e.g., \code{~unit_id}). This formula is passed to the \code{cluster} argument of the \code{sandwich::vcovCL} function.
 \item Square covariance matrix
-\item Function which returns a covariance matrix (e.g., \code{stats::vcov(model)})
+\item Function which returns a covariance matrix (e.g., \code{stats::vcov})
 }}
 
 \item{conf_level}{numeric value between 0 and 1. Confidence level to use to build a confidence interval.}

--- a/man/plot_comparisons.Rd
+++ b/man/plot_comparisons.Rd
@@ -72,13 +72,14 @@ first entry in the error message is used by default.}
 }
 \item One-sided formula which indicates the name of cluster variables (e.g., \code{~unit_id}). This formula is passed to the \code{cluster} argument of the \code{sandwich::vcovCL} function.
 \item Square covariance matrix
-\item Function which returns a covariance matrix (e.g., \code{stats::vcov(model)})
+\item Function which returns a covariance matrix (e.g., \code{stats::vcov})
 }}
 
 \item{conf_level}{numeric value between 0 and 1. Confidence level to use to build a confidence interval.}
 
-\item{wts}{string or numeric: weights to use when computing average contrasts or slopes. These weights only affect the averaging in \verb{avg_*()} or with the \code{by} argument, and not the unit-level estimates themselves. Internally, estimates and weights are passed to the \code{weighted.mean()} function.
+\item{wts}{logical, string, or numeric: weights to use when computing average contrasts or slopes. These weights only affect the averaging in \verb{avg_*()} or with the \code{by} argument, and not the unit-level estimates themselves. Internally, estimates and weights are passed to the \code{weighted.mean()} function.
 \itemize{
+\item logical: if \code{TRUE}, weights will be extracted from the supplied model using \code{\link[insight:get_weights]{insight::get_weights()}}. Only allowed when \code{newdata} is not specified.
 \item string: column name of the weights variable in \code{newdata}. When supplying a column name to \code{wts}, it is recommended to supply the original data (including the weights variable) explicitly to \code{newdata}.
 \item numeric: vector of length equal to the number of rows in the original data or in \code{newdata} (if supplied).
 }}

--- a/man/plot_predictions.Rd
+++ b/man/plot_predictions.Rd
@@ -65,13 +65,14 @@ first entry in the error message is used by default.}
 }
 \item One-sided formula which indicates the name of cluster variables (e.g., \code{~unit_id}). This formula is passed to the \code{cluster} argument of the \code{sandwich::vcovCL} function.
 \item Square covariance matrix
-\item Function which returns a covariance matrix (e.g., \code{stats::vcov(model)})
+\item Function which returns a covariance matrix (e.g., \code{stats::vcov})
 }}
 
 \item{conf_level}{numeric value between 0 and 1. Confidence level to use to build a confidence interval.}
 
-\item{wts}{string or numeric: weights to use when computing average contrasts or slopes. These weights only affect the averaging in \verb{avg_*()} or with the \code{by} argument, and not the unit-level estimates themselves. Internally, estimates and weights are passed to the \code{weighted.mean()} function.
+\item{wts}{logical, string, or numeric: weights to use when computing average contrasts or slopes. These weights only affect the averaging in \verb{avg_*()} or with the \code{by} argument, and not the unit-level estimates themselves. Internally, estimates and weights are passed to the \code{weighted.mean()} function.
 \itemize{
+\item logical: if \code{TRUE}, weights will be extracted from the supplied model using \code{\link[insight:get_weights]{insight::get_weights()}}. Only allowed when \code{newdata} is not specified.
 \item string: column name of the weights variable in \code{newdata}. When supplying a column name to \code{wts}, it is recommended to supply the original data (including the weights variable) explicitly to \code{newdata}.
 \item numeric: vector of length equal to the number of rows in the original data or in \code{newdata} (if supplied).
 }}

--- a/man/plot_slopes.Rd
+++ b/man/plot_slopes.Rd
@@ -71,13 +71,14 @@ first entry in the error message is used by default.}
 }
 \item One-sided formula which indicates the name of cluster variables (e.g., \code{~unit_id}). This formula is passed to the \code{cluster} argument of the \code{sandwich::vcovCL} function.
 \item Square covariance matrix
-\item Function which returns a covariance matrix (e.g., \code{stats::vcov(model)})
+\item Function which returns a covariance matrix (e.g., \code{stats::vcov})
 }}
 
 \item{conf_level}{numeric value between 0 and 1. Confidence level to use to build a confidence interval.}
 
-\item{wts}{string or numeric: weights to use when computing average contrasts or slopes. These weights only affect the averaging in \verb{avg_*()} or with the \code{by} argument, and not the unit-level estimates themselves. Internally, estimates and weights are passed to the \code{weighted.mean()} function.
+\item{wts}{logical, string, or numeric: weights to use when computing average contrasts or slopes. These weights only affect the averaging in \verb{avg_*()} or with the \code{by} argument, and not the unit-level estimates themselves. Internally, estimates and weights are passed to the \code{weighted.mean()} function.
 \itemize{
+\item logical: if \code{TRUE}, weights will be extracted from the supplied model using \code{\link[insight:get_weights]{insight::get_weights()}}. Only allowed when \code{newdata} is not specified.
 \item string: column name of the weights variable in \code{newdata}. When supplying a column name to \code{wts}, it is recommended to supply the original data (including the weights variable) explicitly to \code{newdata}.
 \item numeric: vector of length equal to the number of rows in the original data or in \code{newdata} (if supplied).
 }}

--- a/man/predictions.Rd
+++ b/man/predictions.Rd
@@ -105,7 +105,7 @@ avg_predictions(
 }
 \item One-sided formula which indicates the name of cluster variables (e.g., \code{~unit_id}). This formula is passed to the \code{cluster} argument of the \code{sandwich::vcovCL} function.
 \item Square covariance matrix
-\item Function which returns a covariance matrix (e.g., \code{stats::vcov(model)})
+\item Function which returns a covariance matrix (e.g., \code{stats::vcov})
 }}
 
 \item{conf_level}{numeric value between 0 and 1. Confidence level to use to build a confidence interval.}
@@ -134,8 +134,9 @@ value. This is sometimes used to take the sum or mean of predicted
 probabilities across outcome or predictor
 levels. See examples section.}
 
-\item{wts}{string or numeric: weights to use when computing average contrasts or slopes. These weights only affect the averaging in \verb{avg_*()} or with the \code{by} argument, and not the unit-level estimates themselves. Internally, estimates and weights are passed to the \code{weighted.mean()} function.
+\item{wts}{logical, string, or numeric: weights to use when computing average contrasts or slopes. These weights only affect the averaging in \verb{avg_*()} or with the \code{by} argument, and not the unit-level estimates themselves. Internally, estimates and weights are passed to the \code{weighted.mean()} function.
 \itemize{
+\item logical: if \code{TRUE}, weights will be extracted from the supplied model using \code{\link[insight:get_weights]{insight::get_weights()}}. Only allowed when \code{newdata} is not specified.
 \item string: column name of the weights variable in \code{newdata}. When supplying a column name to \code{wts}, it is recommended to supply the original data (including the weights variable) explicitly to \code{newdata}.
 \item numeric: vector of length equal to the number of rows in the original data or in \code{newdata} (if supplied).
 }}

--- a/man/sanitize_model_specific.Rd
+++ b/man/sanitize_model_specific.Rd
@@ -89,7 +89,7 @@ arguments.}
 }
 \item One-sided formula which indicates the name of cluster variables (e.g., \code{~unit_id}). This formula is passed to the \code{cluster} argument of the \code{sandwich::vcovCL} function.
 \item Square covariance matrix
-\item Function which returns a covariance matrix (e.g., \code{stats::vcov(model)})
+\item Function which returns a covariance matrix (e.g., \code{stats::vcov})
 }}
 
 \item{newdata}{Grid of predictor values at which we evaluate the slopes.
@@ -111,8 +111,9 @@ arguments.}
 }
 }}
 
-\item{wts}{string or numeric: weights to use when computing average contrasts or slopes. These weights only affect the averaging in \verb{avg_*()} or with the \code{by} argument, and not the unit-level estimates themselves. Internally, estimates and weights are passed to the \code{weighted.mean()} function.
+\item{wts}{logical, string, or numeric: weights to use when computing average contrasts or slopes. These weights only affect the averaging in \verb{avg_*()} or with the \code{by} argument, and not the unit-level estimates themselves. Internally, estimates and weights are passed to the \code{weighted.mean()} function.
 \itemize{
+\item logical: if \code{TRUE}, weights will be extracted from the supplied model using \code{\link[insight:get_weights]{insight::get_weights()}}. Only allowed when \code{newdata} is not specified.
 \item string: column name of the weights variable in \code{newdata}. When supplying a column name to \code{wts}, it is recommended to supply the original data (including the weights variable) explicitly to \code{newdata}.
 \item numeric: vector of length equal to the number of rows in the original data or in \code{newdata} (if supplied).
 }}

--- a/man/slopes.Rd
+++ b/man/slopes.Rd
@@ -101,7 +101,7 @@ first entry in the error message is used by default.}
 }
 \item One-sided formula which indicates the name of cluster variables (e.g., \code{~unit_id}). This formula is passed to the \code{cluster} argument of the \code{sandwich::vcovCL} function.
 \item Square covariance matrix
-\item Function which returns a covariance matrix (e.g., \code{stats::vcov(model)})
+\item Function which returns a covariance matrix (e.g., \code{stats::vcov})
 }}
 
 \item{conf_level}{numeric value between 0 and 1. Confidence level to use to build a confidence interval.}
@@ -115,8 +115,9 @@ first entry in the error message is used by default.}
 \item Y is the predicted value of the outcome; X is the observed value of the predictor.
 }}
 
-\item{wts}{string or numeric: weights to use when computing average contrasts or slopes. These weights only affect the averaging in \verb{avg_*()} or with the \code{by} argument, and not the unit-level estimates themselves. Internally, estimates and weights are passed to the \code{weighted.mean()} function.
+\item{wts}{logical, string, or numeric: weights to use when computing average contrasts or slopes. These weights only affect the averaging in \verb{avg_*()} or with the \code{by} argument, and not the unit-level estimates themselves. Internally, estimates and weights are passed to the \code{weighted.mean()} function.
 \itemize{
+\item logical: if \code{TRUE}, weights will be extracted from the supplied model using \code{\link[insight:get_weights]{insight::get_weights()}}. Only allowed when \code{newdata} is not specified.
 \item string: column name of the weights variable in \code{newdata}. When supplying a column name to \code{wts}, it is recommended to supply the original data (including the weights variable) explicitly to \code{newdata}.
 \item numeric: vector of length equal to the number of rows in the original data or in \code{newdata} (if supplied).
 }}


### PR DESCRIPTION
See #1046. There are still some issues to work out:
* When `newdata` is supplied as something other than the original model data, the extracted weights will not have the same length as the supplied `newdata` and will cause an error.
* When `newdata` is supplied as a call to `datagrid()`, the weights are appended after evaluation, when `modeldata` should have the weights appended before being evaluated by `datagrid()`. This leads to the error above.
* The error above is not clear; the user will see that the length of `wts` must match that of `newdata`.
* I didn't re-build the documentation.