### PR TITLE
issue `get_predict.svyglm()` throws "NAs introduced by coercion" when data row names are not integers #1131

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: marginaleffects
 Title: Predictions, Comparisons, Slopes, Marginal Means, and Hypothesis Tests
-Version: 0.20.1.1
+Version: 0.20.1.2
 Authors@R: 
     c(person(given = "Vincent",
              family = "Arel-Bundock",

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 Bugs:
 
 * Fix regression in `mlogit` models due to factor conversion. This raised an error before returning result, so there is no numerical danger.
+* `survey` package models work when `row.names(model)` is not coercible to integers. Thanks to @ngreifer for report #1131.
 
 ## 0.20.1
 

--- a/R/methods_survey.R
+++ b/R/methods_survey.R
@@ -79,7 +79,8 @@ get_predict.svyglm <- function(model,
   if (is.null(rowid)) {
       rowid <- seq_len(estimate)
   } else {
-      rowid <- as.integer(rowid)
+      # rowid might be character, but survey::predict() requires non-negative integers
+      rowid <- seq_along(rowid)
   }
   out <- data.frame(rowid, estimate = as.numeric(estimate))
   row.names(out) <- NULL

--- a/inst/tinytest/test-pkg-survey.R
+++ b/inst/tinytest/test-pkg-survey.R
@@ -29,5 +29,29 @@ expect_equivalent(mfx$estimate, em$nh.trend, tolerance = .001) # CRAN tolerance
 expect_equivalent(mfx$std.error, em$std.error, tolerance = .001)
 
 
+# Issue #1131
+data("lalonde", package = "MatchIt")
+fit <- survey::svyglm(re78 ~ treat, design = survey::svydesign(~1, weights = ~1, data = lalonde))
+p <- marginaleffects::get_predict(fit, newdata = lalonde)
+expect_inherits(p, "data.frame")
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 rm(list = ls())
+
+


### PR DESCRIPTION
#1131