### PR TITLE
Fix more lints

### DIFF
--- a/R/ci.R
+++ b/R/ci.R
@@ -21,7 +21,7 @@ get_ci <- function(
     }
 
     required <- c("estimate", "std.error")
-    if (!inherits(x, "data.frame") || any(!required %in% colnames(x))) {
+    if (!inherits(x, "data.frame") || !all(required %in% colnames(x))) {
         return(x)
     }
 
@@ -116,7 +116,7 @@ get_ci_draws <- function(x, conf_level, draws, model = NULL) {
         insight::check_if_installed("collapse", minimum_version = "1.9.0")
         # Issue #1017
         if (nrow(draws) > 0) {
-            CIs <- collapse::dapply(draws, MARGIN = 1, FUN = collapse::fquantile, probs = c(critical, .5, 1 - critical))
+            CIs <- collapse::dapply(draws, MARGIN = 1, FUN = collapse::fquantile, probs = c(critical, 0.5, 1 - critical))
             x$estimate <- CIs[, 2]
             x$conf.low <- CIs[, 1]
             x$conf.high <- CIs[, 3]

--- a/R/comparisons.R
+++ b/R/comparisons.R
@@ -540,7 +540,7 @@ comparisons <- function(model,
     mfx <- backtransform(mfx, transform)
 
     # save as attribute and not column
-    if (any(!is.na(mfx[["marginaleffects_wts_internal"]]))) {
+    if (!all(is.na(mfx[["marginaleffects_wts_internal"]]))) {
         marginaleffects_wts_internal <- mfx[["marginaleffects_wts_internal"]]
     } else {
         marginaleffects_wts_internal <- NULL

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -77,7 +77,7 @@ predictions(mod,
         insight::format_error("The `equivalence` and `p_adjust` arguments cannot be used together.")
     }
 
-    numderiv = sanitize_numderiv(numderiv)
+    numderiv <- sanitize_numderiv(numderiv)
 
     # build call: match.call() doesn't work well in *apply()
     call_attr <- c(list(

--- a/R/equivalence.R
+++ b/R/equivalence.R
@@ -4,7 +4,7 @@ equivalence <- function(x, equivalence = NULL, df = Inf, ...) {
         return(x)
     } 
     
-    if (!is.null(equivalence) && any(!c("estimate", "std.error") %in% colnames(x))) {
+    if (!is.null(equivalence) && !all(c("estimate", "std.error") %in% colnames(x))) {
         msg <- "The `equivalence` argument is not supported with models for which `marginaleffects` does not estimate a standard error (e.g., bayesian)."
         insight::format_error(msg)
     }

--- a/R/get_contrast_data_character.R
+++ b/R/get_contrast_data_character.R
@@ -31,7 +31,7 @@ get_contrast_data_character <- function(model,
     } else if (isTRUE(checkmate::check_atomic_vector(variable$value, len = 2))) {
         if (is.character(variable$value)) {
             tmp <- modeldata[[variable$name]]
-            if (any(!variable$value %in% as.character(tmp))) {
+            if (!all(variable$value %in% as.character(tmp))) {
                 msg <- "Some of the values supplied to the `variables` argument were not found in the dataset."
                 insight::format_error(msg)
             }

--- a/R/get_contrast_data_factor.R
+++ b/R/get_contrast_data_factor.R
@@ -41,7 +41,7 @@ get_contrast_data_factor <- function(model,
     } else if (isTRUE(checkmate::check_atomic_vector(variable$value, len = 2))) {
         if (is.character(variable$value)) {
             tmp <- modeldata[[variable$name]]
-            if (any(!variable$value %in% as.character(tmp))) {
+            if (!all(variable$value %in% as.character(tmp))) {
                 msg <- "Some of the values supplied to the `variables` argument were not found in the dataset."
                 insight::format_error(msg)
             }

--- a/R/get_contrast_data_numeric.R
+++ b/R/get_contrast_data_numeric.R
@@ -108,8 +108,8 @@ get_contrast_data_numeric <- function(model,
         lab <- make_label(variable$label, lab)
 
     } else if (identical(variable$value, "iqr")) {
-        low <- stats::quantile(xmd, probs = .25, na.rm = TRUE)
-        high <- stats::quantile(xmd, probs = .75, na.rm = TRUE)
+        low <- stats::quantile(xmd, probs = 0.25, na.rm = TRUE)
+        high <- stats::quantile(xmd, probs = 0.75, na.rm = TRUE)
         lab <- make_label(variable$label, c("Q3", "Q1"))
 
     } else if (identical(variable$value, "minmax")) {

--- a/R/get_contrasts.R
+++ b/R/get_contrasts.R
@@ -404,7 +404,7 @@ get_contrasts <- function(model,
         # if comparison returns a single value, then we padded with NA. That
         # also means we don't want `rowid` otherwise we will merge and have
         # useless duplicates.
-        if (any(!idx)) {
+        if (!all(idx)) {
             if (settings_equal("marginaleffects_safefun_return1", TRUE)) {
                 out[, "rowid" := NULL]
             }

--- a/R/get_hypothesis.R
+++ b/R/get_hypothesis.R
@@ -1,4 +1,3 @@
-
 get_hypothesis <- function(
     x,
     hypothesis,
@@ -42,7 +41,7 @@ get_hypothesis <- function(
 
         argnames <- names(formals(hypothesis))
         if (!"x" %in% argnames) insight::format_error("The `hypothesis` function must accept an `x` argument.")
-        if (any(!argnames %in% c("x", "draws"))) {
+        if (!all(argnames %in% c("x", "draws"))) {
             msg <- "The allowable arguments for the `hypothesis` function are: `x` and `draws`"
             insight::format_error(msg)
         }
@@ -355,9 +354,9 @@ eval_string_hypothesis <- function(x, hypothesis, lab) {
     }
 
     if (!is.null(attr(lab, "names"))) {
-        lab = attr(lab, "names")
+        lab <- attr(lab, "names")
     } else {
-        lab = gsub("\\s+", "", lab)
+        lab <- gsub("\\s+", "", lab)
     }
 
     draws <- attr(x, "posterior_draws")

--- a/R/hypotheses.R
+++ b/R/hypotheses.R
@@ -265,7 +265,7 @@ hypotheses <- function(
         }
     }
 
-    numderiv = sanitize_numderiv(numderiv)
+    numderiv <- sanitize_numderiv(numderiv)
 
     # after re-evaluation
     tmp <- sanitize_hypothesis(hypothesis, ...)
@@ -286,7 +286,7 @@ hypotheses <- function(
 
         } else if (inherits(model, "data.frame")) {
             out <- model
-            if (any(!c("term", "estimate") %in% colnames(out))) {
+            if (!all(c("term", "estimate") %in% colnames(out))) {
                 msg <- "`hypothesis` function must return a data.frame with two columns named `term` and `estimate`."
                 insight::format_error(msg)
             }

--- a/R/hypothesis_helper.R
+++ b/R/hypothesis_helper.R
@@ -43,10 +43,10 @@ specify_hypothesis <- function(
     } else if (identical(hypothesis, "sequential")) {
         if (comparison == "difference") {
             hypothesis <- function(x) (x - data.table::shift(x))[2:length(x)]
-            label = function(x) sprintf("(%s) - (%s)", x, data.table::shift(x))[2:length(x)]
+            label <- function(x) sprintf("(%s) - (%s)", x, data.table::shift(x))[2:length(x)]
         } else {
             hypothesis <- function(x) (x / data.table::shift(x))[2:length(x)]
-            label = function(x) sprintf("(%s) / (%s)", x, data.table::shift(x))[2:length(x)]
+            label <- function(x) sprintf("(%s) / (%s)", x, data.table::shift(x))[2:length(x)]
         }
     } else if (identical(hypothesis, "meandev")) {
         hypothesis <- function(x) x - mean(x)

--- a/R/methods_quantreg.R
+++ b/R/methods_quantreg.R
@@ -15,7 +15,7 @@ get_predict.rq <- function(model,
                 out <- data.frame(rowid = newdata$rowid, estimate = out)
                 return(out)
             } else {
-                out = data.frame(rowid = seq_len(length(out)), estimate = out)
+                out <- data.frame(rowid = seq_len(length(out)), estimate = out)
             }
         }
     }
@@ -23,7 +23,7 @@ get_predict.rq <- function(model,
     if (isTRUE(checkmate::check_numeric(out, len = nrow(newdata)))) {
         out <- data.frame(rowid = newdata$rowid, estimate = out)
     } else {
-        out = data.frame(rowid = seq_len(length(out)), estimate = out)
+        out <- data.frame(rowid = seq_len(length(out)), estimate = out)
     }
     return(out)
 }

--- a/R/plot_build.R
+++ b/R/plot_build.R
@@ -99,12 +99,12 @@ plot_build <- function(
             p <- p + ggplot2::geom_pointrange(
                 data = dat,
                 mapping = aes_obj,
-                position = ggplot2::position_dodge(.15))
+                position = ggplot2::position_dodge(0.15))
         } else {
             p <- p + ggplot2::geom_point(
                 data = dat,
                 mapping = aes_obj,
-                position = ggplot2::position_dodge(.15))
+                position = ggplot2::position_dodge(0.15))
         }
 
     # continuous x-axis
@@ -122,7 +122,7 @@ plot_build <- function(
         aes_args$ymin <- aes_args$ymax <- NULL
         aes_obj <- do.call(ggplot2::aes, aes_args)
         if ("conf.low" %in% colnames(dat)) {
-            p <- p + ggplot2::geom_ribbon(data = dat, aes_obj_ribbon, alpha = .1)
+            p <- p + ggplot2::geom_ribbon(data = dat, aes_obj_ribbon, alpha = 0.1)
             p <- p + ggplot2::geom_line(data = dat, aes_obj)
         }
         p <- p + ggplot2::geom_line(data = dat, aes_obj)

--- a/R/sanitize_condition.R
+++ b/R/sanitize_condition.R
@@ -10,7 +10,7 @@ condition_shortcuts <- function(x, tr, shortcuts) {
             min(x, na.rm = TRUE),
             max(x, na.rm = TRUE))
     } else if (identical(tr, "quartile")) {
-        out <- stats::quantile(x, probs = c(.25, .5, .75), na.rm = TRUE)
+        out <- stats::quantile(x, probs = c(0.25, 0.5, 0.75), na.rm = TRUE)
     }
     return(out)
 }

--- a/R/sanitize_numderiv.R
+++ b/R/sanitize_numderiv.R
@@ -10,12 +10,12 @@ sanitize_numderiv <- function(numderiv) {
 
     if (length(numderiv) > 1) {
         if (numderiv[[1]] %in% c("fdforward", "fdcenter")) {
-            if (any(!names(numderiv)[2:length(numderiv)] %in% "eps")) {
+            if (!all(names(numderiv)[2:length(numderiv)] %in% "eps")) {
                 stop("The only valid argument for this numeric differentiation method is `eps`.")
             }
         } else if (numderiv[[1]] == "richardson") {
             valid <- c("eps", "d", "zero_tol", "size", "r", "v")
-            if (any(!names(numderiv)[2:length(numderiv)] %in% valid)) {
+            if (!all(names(numderiv)[2:length(numderiv)] %in% valid)) {
                 stop(sprintf("The only valid arguments for this numeric differentiation method are: %s. See `?numDeriv::grad` for details.", paste(valid, collapse = ", ")), call. = FALSE)
             }
         }

--- a/R/sanitize_variables.R
+++ b/R/sanitize_variables.R
@@ -211,7 +211,7 @@ sanitize_variables <- function(variables,
             } else if (calling_function == "predictions") {
                 # string shortcuts
                 if (identical(predictors[[v]], "iqr")) {
-                    predictors[[v]] <- stats::quantile(modeldata[[v]], probs = c(.25, .75), na.rm = TRUE)
+                    predictors[[v]] <- stats::quantile(modeldata[[v]], probs = c(0.25, 0.75), na.rm = TRUE)
                 } else if (identical(predictors[[v]], "minmax")) {
                     predictors[[v]] <- c(min(modeldata[[v]], na.rm = TRUE), max(modeldata[[v]], na.rm = TRUE))
                 } else if (identical(predictors[[v]], "sd")) {


### PR DESCRIPTION
Hi @vincentarelbundock, I've added [more linting rules](https://github.com/etiennebacher/flint/releases/tag/v0.0.2) in `flint` and here are a few additional fixes. Most of them are replacing `any(!expr)` by `!all(expr)` and adding `0` in front of the decimal when it's missing.

I'm testing on this package so for me there's no cost in proposing those changes, but of course let me know if you'd prefer not having this kind of PR. 