### PR TITLE
add ellipsis to FUNouter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: marginaleffects
 Title: Predictions, Comparisons, Slopes, Marginal Means, and Hypothesis Tests
-Version: 0.22.0.4
+Version: 0.22.0.5
 Authors@R: 
     c(person(given = "Vincent",
              family = "Arel-Bundock",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,17 +2,19 @@
 
 ## Development
 
+Breaking change:
+
+* Support for `mlogit` is deprecated. The reason is that the data structure for these models is one observation-choice per row. Every other model-fitting package supported by `marginaleffects` treats rows as individual observations. The observation-choice structure made it harder to track indices and match individual predictions to rows in the original data. This added a lot of complexity to `marginaleffects`, and the results were not always reliable or safe.
+
 Bugs:
 
-* Standard errors are produced in `glmmTMB` models with `type="zprob"`. Thanks to @jgeller112 for issue #1189.
+* Improved `glmmTMB` support
+    - Standard errors are produced in models with `type="zprob"`. Thanks to @jgeller112 for issue #1189.
+    - `hypotheses()` bug resolved. Thanks to @reikookamoto for the code submission.
 * `multinom_weightit` models with `insight` version 0.20.4 and greater would produce an error. Thanks to Noah Greifer.
 * `hypotheses(joint = TRUE)` would throw an error if sample sizes could not be computed, even if they were not needed. Thanks to Noah Greifer.
 * `hypotheses(joint = TRUE)` respects the `vcov` argument. Thanks to @kennchua for report #1214.
 * `ordbetareg` models in `glmmTMB` are now supported. Thanks to @jgeller112 for code contribution #1221.
-
-Breaking change:
-
-* Support for `mlogit` is deprecated. The reason is that the data structure for these models is one observation-choice per row. Every other model-fitting package supported by `marginaleffects` treats rows as individual observations. The observation-choice structure made it harder to track indices and match individual predictions to rows in the original data. This added a lot of complexity to `marginaleffects`, and the results were not always reliable or safe.
 
 ## 0.22.0
 

--- a/R/hypotheses.R
+++ b/R/hypotheses.R
@@ -277,8 +277,9 @@ hypotheses <- function(
     vcov <- get_vcov(model = model, vcov = vcov)
     vcov.type <- get_vcov_label(vcov = vcov)
 
-    FUNouter <- function(model, hypothesis, ...) {
+    FUNouter <- function(model, hypothesis, newparams = NULL, ...) {
 
+        browser()
         if (inherits(model, c("predictions", "slopes", "comparisons"))) {
             out <- model
 
@@ -297,6 +298,11 @@ hypotheses <- function(
             out <- insight::get_parameters(model, ...)
             idx <- intersect(colnames(model), c("term", "group", "estimate"))
             colnames(out)[1:2] <- c("term", "estimate")
+
+            # glmmTMB
+            if (!is.null(newparams)) {
+                out$estimate <- newparams
+            }
 
         } else if (hypothesis_is_formula) {
             beta <- get_coef(model)
@@ -325,7 +331,7 @@ hypotheses <- function(
         return(out)
     }
 
-    b <- FUNouter(model = model, hypothesis = hypothesis)
+    b <- FUNouter(model = model, hypothesis = hypothesis, ...)
     
     # bayesian posterior
     if (!is.null(attr(b, "posterior_draws"))) {

--- a/R/hypotheses.R
+++ b/R/hypotheses.R
@@ -277,7 +277,7 @@ hypotheses <- function(
     vcov <- get_vcov(model = model, vcov = vcov)
     vcov.type <- get_vcov_label(vcov = vcov)
 
-    FUNouter <- function(model, hypothesis) {
+    FUNouter <- function(model, hypothesis, ...) {
 
         if (inherits(model, c("predictions", "slopes", "comparisons"))) {
             out <- model

--- a/R/hypotheses.R
+++ b/R/hypotheses.R
@@ -279,7 +279,6 @@ hypotheses <- function(
 
     FUNouter <- function(model, hypothesis, newparams = NULL, ...) {
 
-        browser()
         if (inherits(model, c("predictions", "slopes", "comparisons"))) {
             out <- model
 

--- a/inst/tinytest/helpers.R
+++ b/inst/tinytest/helpers.R
@@ -42,9 +42,10 @@ Sys.setenv(TZ = "America/New_York")
 options(width = 10000)
 options(digits = 5)
 
-ON_CRAN <- !identical(Sys.getenv("R_NOT_CRAN"), "true")
-ON_GH <- identical(Sys.getenv("R_GH"), "true")
-ON_CI <- isTRUE(ON_CRAN) || isTRUE(ON_GH)
+ON_LOCAL <- Sys.info()["user"] %in% c("vince", "vincent")
+ON_CRAN <- !identical(Sys.getenv("R_NOT_CRAN"), "true") && !ON_LOCAL
+ON_GH <- identical(Sys.getenv("R_GH"), "true") && !ON_LOCAL
+ON_CI <- (isTRUE(ON_CRAN) || isTRUE(ON_GH)) && !ON_LOCAL
 ON_WINDOWS <- isTRUE(Sys.info()[["sysname"]] == "Windows")
 ON_OSX <- isTRUE(Sys.info()[["sysname"]] == "Darwin")
 

--- a/inst/tinytest/test-pkg-glmmTMB.R
+++ b/inst/tinytest/test-pkg-glmmTMB.R
@@ -1,5 +1,4 @@
 source("helpers.R")
-# if (!EXPENSIVE) exit_file("EXPENSIVE")
 using("marginaleffects")
 
 if (ON_CI) exit_file("on ci") # install and test fails on Github
@@ -267,6 +266,12 @@ p <- avg_predictions(ord_fit, re.form = NA)
 expect_false(anyNA(p$estimate))
 expect_false(anyNA(p$std.error))
 
+
+# Issue 1224
+mod <- glmmTMB(Sepal.Length ~ Petal.Width + (1 | Species), data = iris)
+h <- hypotheses(mod, hypothesis = "b1 - b2 = 0")
+expect_false(anyNA(h$estimate))
+expect_false(anyNA(h$std.error))
 
 
 


### PR DESCRIPTION
This is a follow-up to #1224 

### Part 1: Resolving the error message

This is the full traceback that I get when calling `hypotheses(m, "b1 = b2")`, as shown in the minimum reproducible example in the original issue.
```
9. do.call("FUN", args) at get_se_delta.R#102
8. func(x) at get_jacobian.R#29
7. (function (func, x, eps = NULL)
   {
   baseline <- func(x)
   inner_loop <- function(chunk, ...) { ...
   }
6. do.call(get_jacobian_fdforward, numderiv) at get_jacobian.R#11
5. get_jacobian(func = function (x)
   {
   names(x) <- names(coefs)
   model_tmp <- set_coef(model, x, ...) ...
   }
4. do.call("get_jacobian", args) at get_se_delta.R#112
3. get_se_delta(model = structure(list(obj = list(par = c(beta = 1, beta = 1, beta = 1, beta = 1, betadisp = 0, theta = 0), fn = function (x = last.par[lfixed()],
   ...
   }
2. do.call("get_se_delta", args) at hypotheses.R#344
1. hypotheses(m, "b1 = b2")
```
- My understanding:
   - At 8, the function `func()` refers to `inner()` defined in `get_delta_se.R`
   - `func()` adds an element called `newparams` to the argument list `args`
   - At 9, `"FUN"` refers to `FUNouter()` defined in `hypotheses.R`
   - `FUNouter()` only expects the arguments `model` and `hypothesis`, but the additional `newparams` argument is passed, leading to the error
- Possible resolution:
   - To fix this, I updated the definition of `FUNouter()` by adding an `...` to allow for additional arguments
   - After making this change, I ran `devtools::check()` and it passed with no errors, warnings, or notes

### Part 2: Standard error returned is `NA`

When I call `hypotheses(m, "b1 = b2")` after updating `FUNouter()`, I get the following output:
```
Estimate Std. Error  z Pr(>|z|)  S  2.5 %  97.5 %
    0.634         NA NA       NA NA    NA     NA
```
The returned data frame gives a sensible estimate, but the remaining columns are all `NA`.

- My understanding:
   - "J" matrix returned on line 112 of `get_se_delta.R` is a matrix where all entries are 0
   - The `se` calculated on line 136 is also 0, which gets overwritten by `NA_real_` in the following line
   - Consequently, the computation of the z-statistic, p-value, and confidence interval in `get_ci()` all return NA
- Hypothesis (no pun intended):
   - Could this be related to precision and floating-point arithmetic issues (i.e., subtractions involving very small differences) happening in the `inner_loop()` function defined in `get_jacobian_fdforward()` within `get_jacobian.R`? 

This is pushing my limited knowledge of matrices and the delta method, so I'm not sure if the `NA` values are expected behaviour or if they indicate a deeper issue.

Thanks for your help!