### PR TITLE
CI benchmark: produce table instead of plot

### DIFF
--- a/.github/scripts/benchmarks.R
+++ b/.github/scripts/benchmarks.R
@@ -16,7 +16,7 @@ out <- cross::run(
     library(data.table)
 
     bench::press(
-      N = c(10, 50),
+      N = c(100, 500, 1000, 10000, 50000),
       {
         dat <- data.frame(matrix(rnorm(N * 26), ncol = 26))
         mod <- lm(X1 ~ ., dat)
@@ -32,7 +32,7 @@ out <- cross::run(
           # 26 variables; no standard error
           slopes(mod, vcov = FALSE),
           # 26 variables
-          marginaleffects::slopes(mod),
+          slopes(mod),
           check = FALSE,
           iterations = 5
         )
@@ -53,12 +53,26 @@ unnested <- out |>
   unnest(result) |>
   mutate(expression = as.character(expression))
 
-plot_result <- ggplot(unnested, aes(N, median, color = pkg)) +
-  geom_line(aes(linetype = pkg)) +
+plot_result <- ggplot(unnested, aes(N, median, color = pkg, linetype = pkg)) +
+  geom_line() +
   geom_point() +
-  facet_wrap(~expression) +
+  facet_wrap(
+    ~expression,
+    labeller = labeller(expression = label_wrap_gen(width = 25)),
+    scales = "free_y"
+  ) +
+  labs(
+    y = "Median time (s)",
+    color = "Package version",
+    linetype = "Package version"
+  ) +
   theme_light() +
   theme(
+    strip.text = element_text(color = "white", size = 10),
+    strip.background = element_rect(
+      fill = "#24478f", linetype = "solid",
+      color = "black", linewidth = 1
+    ),
     legend.position = "bottom"
   )
 

--- a/.github/scripts/benchmarks.R
+++ b/.github/scripts/benchmarks.R
@@ -1,9 +1,10 @@
 library(dplyr)
-library(ggplot2)
 library(tidyr)
+library(tinytable)
 
 # Stored in the Github actions workflow
 pr_number <- Sys.getenv("PR_NUMBER")
+# pr_number <- 1244
 
 out <- cross::run(
   pkgs = c(
@@ -16,7 +17,8 @@ out <- cross::run(
     library(data.table)
 
     bench::press(
-      N = c(100, 500, 1000, 10000, 50000),
+      N = 50,
+      # N = c(100, 500, 1000, 10000, 50000),
       {
         dat <- data.frame(matrix(rnorm(N * 26), ncol = 26))
         mod <- lm(X1 ~ ., dat)
@@ -34,7 +36,7 @@ out <- cross::run(
           # 26 variables
           slopes(mod),
           check = FALSE,
-          iterations = 5
+          iterations = 10
         )
       }
     )
@@ -51,32 +53,32 @@ unnested <- out |>
     )
   ) |>
   unnest(result) |>
-  mutate(expression = as.character(expression))
+  mutate(
+    expression = as.character(expression),
+    # Get duration in seconds
+    median = round(as.numeric(median), 3),
+    # Get memory in MB
+    mem_alloc = round(as.numeric(mem_alloc) / 1000000, 3)
+  ) |>
+  select(pkg, expression, median, mem_alloc)
 
-plot_result <- ggplot(unnested, aes(N, median, color = pkg, linetype = pkg)) +
-  geom_line() +
-  geom_point() +
-  facet_wrap(
-    ~expression,
-    labeller = labeller(expression = label_wrap_gen(width = 25)),
-    scales = "free_y"
-  ) +
-  labs(
-    y = "Median time (s)",
-    color = "Package version",
-    linetype = "Package version"
-  ) +
-  theme_light() +
-  theme(
-    strip.text = element_text(color = "white", size = 10),
-    strip.background = element_rect(
-      fill = "#24478f", linetype = "solid",
-      color = "black", linewidth = 1
-    ),
-    legend.position = "bottom"
+final <- unnested |>
+  pivot_wider(
+    id_cols = expression,
+    names_from = pkg,
+    values_from = c(median, mem_alloc)
+  ) |>
+  mutate(
+    median_diff_main_pr = round((median_PR - median_main) / median_main * 100, 2),
+    median_PR = paste0(median_PR, " (", median_diff_main_pr, "%)"),
+    mem_alloc_diff_main_pr = round((mem_alloc_PR - mem_alloc_main) / mem_alloc_main * 100, 2),
+    mem_alloc_PR = paste0(mem_alloc_PR, " (", mem_alloc_diff_main_pr, "%)")
+  ) |>
+  select(
+    Expression = expression,
+    `Median time with PR (% change with main)` = median_PR,
+    `Memory used with PR (% change with main)` = mem_alloc_PR
   )
 
-ggsave(
-  plot = plot_result,
-  ".github/scripts/benchmark_result.png"
-)
+tt(final) |>
+  save_tt("report.md")

--- a/.github/scripts/benchmarks.R
+++ b/.github/scripts/benchmarks.R
@@ -4,7 +4,6 @@ library(tinytable)
 
 # Stored in the Github actions workflow
 pr_number <- Sys.getenv("PR_NUMBER")
-# pr_number <- 1244
 
 out <- cross::run(
   pkgs = c(
@@ -17,26 +16,51 @@ out <- cross::run(
     library(data.table)
 
     bench::press(
-      N = 50,
-      # N = c(100, 500, 1000, 10000, 50000),
+      N = 75000,
       {
         dat <- data.frame(matrix(rnorm(N * 26), ncol = 26))
         mod <- lm(X1 ~ ., dat)
+
+        set.seed(1234)
+        dat2 <- data.frame(
+          outcome = sample(0:1, N, TRUE),
+          incentive = runif(N),
+          agecat = sample(c("18-35", "35-60", "60+"), N, TRUE),
+          distance = sample(0:10000, N, TRUE)
+        )
+
+        mod2 <- glm(outcome ~ incentive * (agecat + distance),
+          data = dat2, family = binomial
+        )
+        grid <- data.frame(distance = 2, agecat = "18-35", incentive = 1)
+
         bench::mark(
-          # marginal effects at the mean; no standard error
-          slopes(mod, vcov = FALSE, newdata = "mean"),
-          # marginal effects at the mean
-          slopes(mod, newdata = "mean"),
-          # 1 variable; no standard error
-          slopes(mod, vcov = FALSE, variables = "X3"),
-          # 1 variable
-          slopes(mod, variables = "X3"),
-          # 26 variables; no standard error
-          slopes(mod, vcov = FALSE),
-          # 26 variables
-          slopes(mod),
           check = FALSE,
-          iterations = 10
+          iterations = 20,
+
+          # Slopes =========================================
+          slopes(mod, vcov = FALSE, newdata = "mean"),
+          slopes(mod, newdata = "mean"),
+          slopes(mod, vcov = FALSE, variables = "X3"),
+          slopes(mod, variables = "X3"),
+          slopes(mod, vcov = FALSE),
+          slopes(mod),
+
+          # Hypothesis =========================================
+          hypotheses(mod, hypothesis = "b3 - b1 = 0"),
+          hypotheses(mod, hypothesis = "b2^2 * exp(b1) = 0"),
+          hypotheses(mod, hypothesis = ~reference),
+
+          # Predictions =========================================
+          predictions(mod),
+          predictions(mod, newdata = "mean"),
+          predictions(mod, newdata = datagrid(X2 = unique)),
+
+          # Comparisons =========================================
+          comparisons(mod2),
+          comparisons(mod2, comparison = "dydxavg"),
+          comparisons(mod2, comparison = "eydxavg"),
+          comparisons(mod2, comparison = "ratioavg")
         )
       }
     )
@@ -69,16 +93,47 @@ final <- unnested |>
     values_from = c(median, mem_alloc)
   ) |>
   mutate(
+    # Compute change in time and memory between PR/main branch and PR/CRAN
     median_diff_main_pr = round((median_PR - median_main) / median_main * 100, 2),
-    median_PR = paste0(median_PR, " (", median_diff_main_pr, "%)"),
+    median_diff_CRAN_pr = round((median_PR - median_CRAN) / median_CRAN * 100, 2),
+
+    # Compute change in time and memory between PR and CRAN
     mem_alloc_diff_main_pr = round((mem_alloc_PR - mem_alloc_main) / mem_alloc_main * 100, 2),
-    mem_alloc_PR = paste0(mem_alloc_PR, " (", mem_alloc_diff_main_pr, "%)")
+    mem_alloc_diff_CRAN_pr = round((mem_alloc_PR - mem_alloc_CRAN) / mem_alloc_CRAN * 100, 2),
+    across(
+      .cols = c(
+        median_diff_main_pr, median_diff_CRAN_pr,
+        mem_alloc_diff_main_pr, mem_alloc_diff_CRAN_pr
+      ),
+      function(x) {
+        case_when(
+          x >= 5 ~ paste0(":collision: ", x, "%"),
+          x < 5 & x > -5 ~ paste0(x, "%"),
+          x <= -5 ~ paste0(":zap: ", x, "%"),
+          .default = NA
+        )
+      }
+    ),
   ) |>
   select(
     Expression = expression,
-    `Median time with PR (% change with main)` = median_PR,
-    `Memory used with PR (% change with main)` = mem_alloc_PR
+    `PR time (median, seconds)` = median_PR,
+    "% change with `main`" = median_diff_main_pr,
+    "% change with CRAN" = median_diff_CRAN_pr,
+    `PR memory (MB)` = mem_alloc_PR,
+    "Mem. % change with `main`" = mem_alloc_diff_main_pr,
+    "Mem. % change with CRAN" = mem_alloc_diff_CRAN_pr,
   )
 
-tt(final) |>
-  save_tt("report.md")
+raw_table <- tt(final) |>
+  save_tt("gfm")
+
+paste0(
+  "**Benchmark results**\n\n",
+  ":collision: means that PR is more than 5% slower than main or CRAN\n",
+  ":zap: means that PR is more than 5% faster than main or CRAN\n",
+  "<details>\n<summary>Click to see benchmark results</summary>\n\n",
+  raw_table,
+  "\n\n</details>"
+) |>
+  writeLines("report.md")

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -39,12 +39,15 @@ jobs:
         with:
           use-public-rspm: true
 
+      - name: Pandoc setup
+        uses: r-lib/actions/setup-pandoc@v2
+
       - name: Install required dependencies for benchmark
         run: |
-          install.packages(c("remotes", "bench", "dplyr", "tidyr", "tinytable"))
+          install.packages(c("remotes", "bench", "dplyr", "Formula", "pandoc", "tidyr", "tinytable"))
           remotes::install_github("DavisVaughan/cross")
         shell: Rscript {0}
-
+  
       - name: Run benchmark script
         run: |
           source(".github/scripts/benchmarks.R", echo = TRUE)

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install required dependencies for benchmark
         run: |
-          install.packages(c("remotes", "bench", "dplyr", "tidyr", "ggplot2"))
+          install.packages(c("remotes", "bench", "dplyr", "tidyr"))
           remotes::install_github("DavisVaughan/cross")
         shell: Rscript {0}
 
@@ -60,7 +60,6 @@ jobs:
       - name: Push generated plot as a GH-bot comment
         run: |
           # Comment contents:
-          echo "[![Comparison Plot](./.github/scripts/benchmark_result.png)](./.github/scripts/benchmark_result.png)" >> report.md
           echo -e "\nGenerated via commit ${{ github.event.pull_request.head.sha }}" >> report.md
           echo -e "\nDownload link for the artifact containing the test results: [↓ benchmark-results.zip](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.artifact-upload-step.outputs.artifact-id }})" >> report.md
           cml comment update report.md

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install required dependencies for benchmark
         run: |
-          install.packages(c("remotes", "bench", "dplyr", "tidyr"))
+          install.packages(c("remotes", "bench", "dplyr", "tidyr", "tinytable"))
           remotes::install_github("DavisVaughan/cross")
         shell: Rscript {0}
 


### PR DESCRIPTION
Gives this (with only 10 and 50 obs):

![image](https://github.com/user-attachments/assets/627e6a65-883a-4a1a-8489-f7a0d9e47899)
