### PR TITLE
Update plot_build.R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: marginaleffects
 Title: Predictions, Comparisons, Slopes, Marginal Means, and Hypothesis Tests
-Version: 0.23.0.2
+Version: 0.23.0.3
 Authors@R: 
     c(person(given = "Vincent",
              family = "Arel-Bundock",

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ Bugs:
 
 Misc:
 
+* The `ggplot2` object returned by `plot_*()` functions now includes the estimates as a default object. This allows things like: `plot_predictions(model, condition="x")+geom_line()`. Thanks to @mattansb for code contribution #1259.
 * Be less strict about combining columns of different types. This allows us to handle types like `haven_labelled`. Thanks to @mwindzio for report #1238.
 
 ## 0.23.0

--- a/R/plot_build.R
+++ b/R/plot_build.R
@@ -53,7 +53,7 @@ plot_build <- function(
     dat$marginaleffects_term_index <- get_unique_index(dat, term_only = TRUE)
     multi_variables <- isTRUE(length(unique(dat$marginaleffects_term_index)) > 1)
 
-    p <- ggplot2::ggplot()
+    p <- ggplot2::ggplot(data = dat)
 
     if (points > 0 &&
         !get_variable_class(modeldata, v_x, "categorical") &&
@@ -102,12 +102,10 @@ plot_build <- function(
         aes_obj <- do.call(ggplot2::aes, aes_args)
         if ("conf.low" %in% colnames(dat)) {
             p <- p + ggplot2::geom_pointrange(
-                data = dat,
                 mapping = aes_obj,
                 position = ggplot2::position_dodge(0.15))
         } else {
             p <- p + ggplot2::geom_point(
-                data = dat,
                 mapping = aes_obj,
                 position = ggplot2::position_dodge(0.15))
         }
@@ -127,10 +125,10 @@ plot_build <- function(
         aes_args$ymin <- aes_args$ymax <- NULL
         aes_obj <- do.call(ggplot2::aes, aes_args)
         if ("conf.low" %in% colnames(dat)) {
-            p <- p + ggplot2::geom_ribbon(data = dat, aes_obj_ribbon, alpha = 0.1)
-            p <- p + ggplot2::geom_line(data = dat, aes_obj)
+            p <- p + ggplot2::geom_ribbon(aes_obj_ribbon, alpha = 0.1)
+            p <- p + ggplot2::geom_line(aes_obj)
         }
-        p <- p + ggplot2::geom_line(data = dat, aes_obj)
+        p <- p + ggplot2::geom_line(aes_obj)
     }
 
     # facets: 3rd and 4th variable and/or multiple effects


### PR DESCRIPTION
Currently, the internal `plot_build()` function pieces together the plot in such a way that the plot cannot easily be extended.

For example:

``` r
library(marginaleffects)
library(ggplot2)

mtcars$cyl <- factor(mtcars$cyl)

mod <- lm(mpg ~ cyl * am, data = mtcars)

(p <- plot_predictions(mod, condition = c("cyl", "am")))
```

![](https://i.imgur.com/6SfvaBY.png)<!-- -->

I would like to add a connecting line, but… (does nothing)

``` r
p + geom_line()
```

![](https://i.imgur.com/riKN02b.png)<!-- -->

This is because there is no default data frame

``` r
p$data
#> list()
#> attr(,"class")
#> [1] "waiver"
```

Nor any default mapped variables:

``` r
p$mapping
#> Aesthetic mapping: 
#> <empty>
```

<sup>Created on 2024-10-29 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>


This small PR makes this possible by adding default data - the estimates. I've left the default mapped variables empty, since this would require dealing with conflicts of aesthetics inheritance. But it still works and allows for much flexibility:

``` r

p$data
#> 
#>  cyl am Estimate Std. Error     z Pr(>|z|)     S 2.5 % 97.5 %
#>    6  0     19.1      1.516 12.61   <0.001 118.8  16.2   22.1
#>    6  1     20.6      1.751 11.75   <0.001 103.4  17.1   24.0
#>    4  0     22.9      1.751 13.08   <0.001 127.5  19.5   26.3
#>    4  1     28.1      1.072 26.19   <0.001 499.7  26.0   30.2
#>    8  0     15.1      0.875 17.19   <0.001 217.7  13.3   16.8
#>    8  1     15.4      2.144  7.18   <0.001  40.4  11.2   19.6
#> 
#> Type:  response 
#> Columns: rowid, estimate, std.error, statistic, p.value, s.value, conf.low, conf.high, cyl, am, mpg

p + geom_line(aes(cyl, estimate, group = factor(am)),
              position = position_dodge(0.15))
```

![](https://i.imgur.com/iZBy8HQ.png)<!-- -->

<sup>Created on 2024-10-29 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

