### PR TITLE
Retain "by" and "conf_level" attributes for lean objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: marginaleffects
 Title: Predictions, Comparisons, Slopes, Marginal Means, and Hypothesis Tests
-Version: 0.24.0.3
+Version: 0.24.0.4
 Authors@R: 
     c(person(given = "Vincent",
              family = "Arel-Bundock",

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Development
 
 * Version 0.24.0 accidentally removed the "contrast" column from the output object in calls with only one focal predictor. This column is reinstated.
+* Reinstate some attributes lost with `marginaleffects_lean` but necessary for printing.
 * More informative warning for `lme4` and `glmmTMB` models with `re.form=NULL`
 
 Bugs:

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 Bugs:
 
 * Encoding issue in bayesian models with `by`. Thanks to @Koalha for report #1290.
+* Retain necessary attribute information to ensure that "lean" return objects still print correctly #1295. 
 
 ## 0.24.0
 

--- a/R/comparisons.R
+++ b/R/comparisons.R
@@ -547,15 +547,16 @@ comparisons <- function(model,
     get_marginaleffects_attributes(newdata, include_regex = "^newdata.*class|explicit|matrix|levels"))
 
   # Global option for lean return object
-  lean = getOption("marginaleffects_lean", default = FALSE)
+  lean <- getOption("marginaleffects_lean", default = FALSE)
 
   # Only add (potentially large) attributes if lean is FALSE
+  # extra attributes needed for print method, even with lean return object
+  attr(out, "conf_level") <- conf_level
+  attr(out, "by") <- by
+  attr(out, "lean") <- lean
+  attr(out, "vcov.type") <- vcov.type
   if (isTRUE(lean)) {
-    for (a in setdiff(names(attributes(out)), c("names", "row.names", "class"))) attr(out, a) = NULL
-    ## extra attributes needed for print method, even with lean return object
-    attr(out, "conf_level") <- conf_level
-    attr(out, "by") <- by
-    attr(out, "lean") <- TRUE
+    for (a in setdiff(names(attributes(out)), c("names", "row.names", "class"))) attr(out, a) <- NULL
   } else {
     # other attributes
     attr(out, "newdata") <- newdata
@@ -573,8 +574,6 @@ comparisons <- function(model,
     attr(out, "comparison_label") <- comparison_label
     attr(out, "hypothesis_by") <- hyp_by
     attr(out, "transform_label") <- transform_label
-    attr(out, "conf_level") <- conf_level
-    attr(out, "by") <- by
 
     if (inherits(model, "brmsfit")) {
       insight::check_if_installed("brms")

--- a/R/comparisons.R
+++ b/R/comparisons.R
@@ -552,6 +552,9 @@ comparisons <- function(model,
   # Only add (potentially large) attributes if lean is FALSE
   if (isTRUE(lean)) {
     for (a in setdiff(names(attributes(out)), c("names", "row.names", "class"))) attr(out, a) = NULL
+    ## extra attributes needed for print method, even with lean return object
+    attr(out, "conf_level") <- conf_level
+    attr(out, "by") <- by
     attr(out, "lean") <- TRUE
   } else {
     # other attributes

--- a/R/predictions.R
+++ b/R/predictions.R
@@ -543,30 +543,35 @@ predictions <- function(model,
   out <- set_marginaleffects_attributes(out, attr_cache = newdata_attr_cache)
 
   # Global option for lean return object
-  lean = getOption("marginaleffects_lean", default = FALSE)
+  lean <- getOption("marginaleffects_lean", default = FALSE)
 
-  # Only add (potentially large) attributes if lean isn't TRUE
+  # Only add (potentially large) attributes if lean is FALSE
+  # extra attributes needed for print method, even with lean return object
+  attr(out, "conf_level") <- conf_level
+  attr(out, "by") <- by
+  attr(out, "lean") <- lean
+  attr(out, "vcov.type") <- vcov.type
   if (isTRUE(lean)) {
-    for (a in setdiff(aa, c("names", "row.names", "class"))) attr(mfx, a) = NULL
-    attr(out, "lean") <- TRUE
+    for (a in setdiff(names(attributes(out)), c("names", "row.names", "class"))) {
+      attr(out, a) <- NULL
+    }
   } else {
     # other attributes
-    attr(out, "model") <- model
-    attr(out, "type") <- type_string
-    attr(out, "model_type") <- class(model)[1]
-    attr(out, "vcov.type") <- get_vcov_label(vcov)
-    attr(out, "jacobian") <- J
-    attr(out, "vcov") <- V
     attr(out, "newdata") <- newdata
-    attr(out, "weights") <- marginaleffects_wts_internal
-    attr(out, "conf_level") <- conf_level
-    attr(out, "by") <- by
     attr(out, "call") <- call_attr
-    attr(out, "hypothesis_by") <- hyp_by
-    attr(out, "transform_label") <- names(transform)[1]
+    attr(out, "type") <- type
+    attr(out, "model_type") <- class(model)[1]
+    attr(out, "model") <- model
+    attr(out, "variables") <- predictors
+    attr(out, "jacobian") <- J
+    attr(out, "vcov") <- vcov
+    attr(out, "vcov.type") <- vcov.type
+    attr(out, "weights") <- marginaleffects_wts_internal
+    attr(out, "comparison") <- comparison
     attr(out, "transform") <- transform[[1]]
-    # save newdata for use in recall()
-    attr(out, "newdata") <- newdata
+    attr(out, "comparison_label") <- comparison_label
+    attr(out, "hypothesis_by") <- hyp_by
+    attr(out, "transform_label") <- transform_label
 
     if (inherits(model, "brmsfit")) {
       insight::check_if_installed("brms")

--- a/R/predictions.R
+++ b/R/predictions.R
@@ -550,7 +550,6 @@ predictions <- function(model,
   attr(out, "conf_level") <- conf_level
   attr(out, "by") <- by
   attr(out, "lean") <- lean
-  attr(out, "vcov.type") <- vcov.type
   if (isTRUE(lean)) {
     for (a in setdiff(names(attributes(out)), c("names", "row.names", "class"))) {
       attr(out, a) <- NULL
@@ -562,16 +561,11 @@ predictions <- function(model,
     attr(out, "type") <- type
     attr(out, "model_type") <- class(model)[1]
     attr(out, "model") <- model
-    attr(out, "variables") <- predictors
     attr(out, "jacobian") <- J
     attr(out, "vcov") <- vcov
-    attr(out, "vcov.type") <- vcov.type
     attr(out, "weights") <- marginaleffects_wts_internal
-    attr(out, "comparison") <- comparison
     attr(out, "transform") <- transform[[1]]
-    attr(out, "comparison_label") <- comparison_label
     attr(out, "hypothesis_by") <- hyp_by
-    attr(out, "transform_label") <- transform_label
 
     if (inherits(model, "brmsfit")) {
       insight::check_if_installed("brms")

--- a/R/predictions.R
+++ b/R/predictions.R
@@ -550,6 +550,7 @@ predictions <- function(model,
   attr(out, "conf_level") <- conf_level
   attr(out, "by") <- by
   attr(out, "lean") <- lean
+  attr(out, "type") <- type_string
   if (isTRUE(lean)) {
     for (a in setdiff(names(attributes(out)), c("names", "row.names", "class"))) {
       attr(out, a) <- NULL
@@ -558,7 +559,6 @@ predictions <- function(model,
     # other attributes
     attr(out, "newdata") <- newdata
     attr(out, "call") <- call_attr
-    attr(out, "type") <- type
     attr(out, "model_type") <- class(model)[1]
     attr(out, "model") <- model
     attr(out, "jacobian") <- J


### PR DESCRIPTION
Fixes #1295.

Old behaviour:

``` r
options(marginaleffects_lean = TRUE)

mod = lm(Sepal.Length ~ Petal.Length * Species, data = iris)
slopes(mod, variable = "Petal.Length", by = "Species")
#> 
#>  Estimate Std. Error     z Pr(>|z|)    S    CI low CI high
#>     0.542     0.2768  1.96   0.0501  4.3 -0.000165    1.08
#>     0.828     0.1023  8.10   <0.001 50.7  0.627824    1.03
#>     0.996     0.0871 11.43   <0.001 98.2  0.825054    1.17
#> 
#> Term: Petal.Length
#> Comparison: mean(dY/dX)
#> Columns: term, contrast, Species, estimate, std.error, statistic, p.value, s.value, conf.low, conf.high, predicted_lo, predicted_hi, predicted
```

New behaviour:

``` r
options(marginaleffects_lean = TRUE)

mod = lm(Sepal.Length ~ Petal.Length * Species, data = iris)
slopes(mod, variable = "Petal.Length", by = "Species")
#> 
#>          Term    Species Estimate Std. Error     z Pr(>|z|)    S     2.5 %
#>  Petal.Length setosa        0.542     0.2768  1.96   0.0501  4.3 -0.000165
#>  Petal.Length versicolor    0.828     0.1023  8.10   <0.001 50.7  0.627824
#>  Petal.Length virginica     0.996     0.0871 11.43   <0.001 98.2  0.825054
#>  97.5 %
#>    1.08
#>    1.03
#>    1.17
#> 
#> Comparison: dY/dX
#> Columns: term, contrast, Species, estimate, std.error, statistic, p.value, s.value, conf.low, conf.high
```

