### PR TITLE
Better concatenation of warning message

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -56,14 +56,13 @@ set_marginaleffects_attributes <- function(x, attr_cache, prefix = "") {
 
 
 warn_once <- function(msg, id) {
-    msg <- c(msg, "", "This warning appears once per session.")
-    if (isTRUE(getOption(id, default = TRUE))) {
-        # insight::format_warning(msg, call. = FALSE)
-        warning(msg, call. = FALSE)
-        opts <- list(FALSE)
-        names(opts) <- id
-        options(opts)
-    }
+    if (!isTRUE(getOption(id, default = TRUE))) return(invisible())
+    msg <- paste(msg, "This warning appears once per session.")
+    # insight::format_warning(msg, call. = FALSE)
+    warning(msg, call. = FALSE)
+    opts <- list(FALSE)
+    names(opts) <- id
+    options(opts)
 }
 
 


### PR DESCRIPTION
Observed in data.table's revdeps checker logs:

```
It is safer and faster to convert such variables to factor before fitting the model and calling a `marginaleffects` function.This warning appears once per session.
```

Note that `warning()` concatenates its inputs with `''`:

```r
warning(letters)
# Warning message:
# abcdefghijklmnopqrstuvwxyz 
```

I'm not familiar with how `insight::format_warning()` handles vectors, so I opted to just build the string directly.