### PR TITLE
Minor performance improvement in `bootstrap_boot()`

### DIFF
--- a/R/bootstrap_boot.R
+++ b/R/bootstrap_boot.R
@@ -40,7 +40,7 @@ bootstrap_boot <- function(model, INF_FUN, ...) {
     # print.boot prints an ugly nested call
     t <- matrix(B$t, nrow = nrow(B$t))
     op <- cbind(
-        apply(t, 2L, mean, na.rm = TRUE),
+        colMeans(t, na.rm = TRUE),
         sqrt(apply(t, 2L, function(t.st) stats::var(t.st[!is.na(t.st)]))))
     out$std.error <- op[, 2]
 


### PR DESCRIPTION
Caught with `flint`. I don't know if this is gonna have a meaningful impact but always nice to get those low-hanging fruits I think:

``` r
mat <- matrix(
  sample(c(1:100, NA), 1e7, replace = TRUE), 
  nrow = 500
)

bench::mark(
  apply(mat, 2, mean, na.rm = TRUE),
  colMeans(mat, na.rm = TRUE)
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 × 6
#>   expression                           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 apply(mat, 2, mean, na.rm = TR… 237.74ms 269.86ms      3.71     312MB     22.2
#> 2 colMeans(mat, na.rm = TRUE)       7.37ms   7.41ms    135.       181KB      0
```

---

Edit: CI failures also occur on `main`
