### PR TITLE
Improved printing when output is split

### DIFF
--- a/R/comparisons.R
+++ b/R/comparisons.R
@@ -69,7 +69,7 @@
 #' + [dplyr::filter()] call with a single argument to select a subset of the dataset used to fit the model, ex: `newdata = filter(treatment == 1)`
 #' @param comparison How should pairs of predictions be compared? Difference, ratio, odds ratio, or user-defined functions.
 #' * string: shortcuts to common contrast functions.
-#'   - Supported shortcuts strings: `r paste(names(marginaleffects:::comparison_function_dict), collapse = ", ")`
+#'   - Supported shortcuts strings: `r toString(names(marginaleffects:::comparison_function_dict))`
 #'   - See the Comparisons section below for definitions of each transformation.
 #' * function: accept two equal-length numeric vectors of adjusted predictions (`hi` and `lo`) and returns a vector of contrasts of the same length, or a unique numeric value.
 #'   - See the Transformations section below for examples of valid functions.

--- a/R/datagrid.R
+++ b/R/datagrid.R
@@ -453,7 +453,7 @@ prep_datagrid <- function(..., model = NULL, newdata = NULL, by = NULL) {
         warning(
             sprintf(
                 "Some of the variable names are missing from the model data: %s",
-                paste(variables_missing, collapse = ", ")
+                toString(variables_missing)
             ),
             call. = FALSE
         )
@@ -497,14 +497,14 @@ prep_datagrid <- function(..., model = NULL, newdata = NULL, by = NULL) {
             at[[n]] <- as.character(at[[n]])
             if (!all(at[[n]] %in% c(levs, NA))) {
                 msg <- sprintf(
-                    'The "%s" element of the `at` list corresponds to a factor variable. The values entered in the `at` list must be one of the factor levels: "%s".',
+                    'The "%s" element of the `at` list corresponds to a factor variable. The values entered in the `at` list must be one of the factor levels: %s.',
                     n,
-                    paste(levels(newdata[[n]]), collapse = '", "')
+                    toString(dQuote(levels(newdata[[n]]), NULL))
                 )
                 stop(msg, call. = FALSE)
-            } else {
-                at[[n]] <- factor(at[[n]], levels = levs)
             }
+
+            at[[n]] <- factor(at[[n]], levels = levs)
         }
     }
 

--- a/R/methods_gamlss.R
+++ b/R/methods_gamlss.R
@@ -3,12 +3,12 @@
 #' @export
 get_coef.gamlss <- function(model, ...){
   dots <- list(...)
-  
+
   if (is.null(dots$what))
     stop("Argument `what` indicating the parameter of interest is missing.")
-  
+
   out <- stats::coef(model, what = dots$what)
-  
+
   return(out)
 }
 
@@ -22,23 +22,23 @@ get_predict.gamlss <- function(
     type = "response",
     ...) {
 
- 
+
   # Get predictions
-  
+
   dots <- list(...)
-  
+
   if (is.null(dots$what)) {
       msg <- sprintf(
           "Please specifiy a `what` argument with one of these values: %s",
-          paste(model$parameter, collapse = ", "))
+          toString(model$parameter))
       stop(msg, call. = FALSE)
   }
-  
+
   # if (!isTRUE(checkmate::check_flag(vcov, null.ok = TRUE))) {
   #   msg <- "The `vcov` argument is not supported for models of this class."
   #   stop(msg, call. = FALSE)
   # }
-  
+
   # predict.gamlss() breaks when `newdata` includes unknown variables
   origindata <- insight::get_data(model)
   originvars <- colnames(origindata)
@@ -46,13 +46,13 @@ get_predict.gamlss <- function(
   index <- which(colnames(newdata) %in% originvars)
   tmp <- newdata[, index]
   hush(out <- predict_gamlss(model, newdata = tmp, type = type, data = origindata, ...))
-  
+
   if ("rowid" %in% colnames(newdata)) {
     out <- data.frame(rowid = newdata$rowid, estimate = out)
   } else {
     out <- data.frame(rowid = seq_along(out), estimate = out)
   }
-  
+
   return(out)
 }
 
@@ -61,20 +61,20 @@ get_predict.gamlss <- function(
 #' @export
 get_vcov.gamlss <- function(model, ...){
   dots <- list(...)
-  
+
   if (is.null(dots$what)) {
       msg <- sprintf(
           "Please specifiy a `what` argument with one of these values: %s",
-          paste(model$parameter, collapse = ", "))
+          toString(model$parameter))
       stop(msg, call. = FALSE)
   }
-  
+
   p <- match(dots$what, model$parameters)
-  
-  vc <- stats::vcov(model, what = dots$what) 
+
+  vc <- stats::vcov(model, what = dots$what)
   index <- which(cumsum(rownames(vc) == "(Intercept)") == p)
   out <- vc[index, index, drop = FALSE]
-  
+
   return(out)
 }
 
@@ -83,14 +83,14 @@ get_vcov.gamlss <- function(model, ...){
 #' @export
 set_coef.gamlss <- function(model, coefs, ...){
   dots <- list(...)
-  
+
   if (is.null(dots$what))
     stop("Argument `what` indicating the parameter of interest is missing.")
-  
+
   p <- paste0(dots$what, ".coefficients")
   model[[p]][names(coefs)] <- coefs
   out <- model
-  
+
   return(out)
 }
 

--- a/R/methods_mlr3.R
+++ b/R/methods_mlr3.R
@@ -4,7 +4,7 @@
 #' @export
 get_predict.Learner <- function(model, newdata, type = NULL, ...) {
     if (!is.null(type) && !type %in% model$predict_types) {
-        msg <- sprintf("Valid `type` values: %s", paste(model$predict_types, collapse = ", "))
+        msg <- sprintf("Valid `type` values: %s", toString(model$predict_types))
         insight::format_error(msg)
     }
     out <- drop(stats::predict(model, newdata = newdata, predict_type = type))

--- a/R/print.R
+++ b/R/print.R
@@ -170,13 +170,13 @@ print.marginaleffects <- function(x,
       error = function(e) NULL)
   )
 
-  if ("term" %in% colnames(out) && length(unique(out$term)) == 1) {
-    print_term_text <- sprintf("Term: %s\n", out[["term"]][1])
+  if ("term" %in% colnames(out) && length(unique(out$term)) == 1L) {
+    print_term_text <- sprintf("Term: %s\n", out[["term"]][1L])
     useless <- c(useless, "term")
   }
 
-  if ("contrast" %in% colnames(out) && length(unique(out$contrast)) == 1) {
-    print_contrast_text <- sprintf("Comparison: %s\n", out[["contrast"]][1])
+  if ("contrast" %in% colnames(out) && length(unique(out$contrast)) == 1L) {
+    print_contrast_text <- sprintf("Comparison: %s\n", out[["contrast"]][1L])
     useless <- c(useless, "contrast")
   }
 
@@ -205,11 +205,11 @@ print.marginaleffects <- function(x,
 
   # Footnotes
   if (ncol(x) <= ncols && isTRUE(column_names)) {
-    print_columns_text <- paste("Columns:", paste(colnames(x), collapse = ", "), "\n")
+    print_columns_text <- sprintf("Columns: %s\n", toString(colnames(x)))
   }
 
   if (isTRUE(type) && !is.null(attr(x, "type"))) {
-    print_type_text <- paste("Type: ", attr(x, "type"), "\n")
+    print_type_text <- sprintf("Type: %s\n", attr(x, "type"))
   }
 
   # avoid infinite recursion by stripping marginaleffect.summary class
@@ -255,14 +255,17 @@ print.marginaleffects <- function(x,
 
   # some commands do not generate average contrasts/mfx. E.g., `lnro` with `by`
   if (splitprint) {
-    print(utils::head(out, n = topn), row.names = FALSE)
-    msg <- "--- %s rows omitted. See ?print.marginaleffects ---"
+    tmp <- utils::capture.output(print(out, row.names = FALSE))
+
+    top <- paste(tmp[seq_len(topn + 1)], collapse = "\n")
+    cat(top)
+
+    msg <- "\n--- %s rows omitted. See ?print.marginaleffects ---\n"
     msg <- sprintf(msg, nrow(x) - 2 * topn)
-    cat(msg, "\n")
-    # remove colnames
-    tmp <- utils::capture.output(print(utils::tail(out, n = topn), row.names = FALSE))
-    tmp <- paste(tmp[-1], collapse = "\n")
-    cat(tmp)
+    cat(msg)
+
+    bottom <- paste(tmp[-seq_len(topn + 1)], collapse = "\n")
+    cat(bottom)
   } else {
     print(out, row.names = FALSE)
   }

--- a/R/sanitize_condition.R
+++ b/R/sanitize_condition.R
@@ -54,11 +54,11 @@ sanitize_condition <- function(model, condition, variables = NULL, modeldata = N
     }
     resp <- insight::get_response(model)
     respname <- insight::find_response(model)
-    
+
     flag <-  checkmate::check_true(all(names(condition) %in% c(colnames(dat), "group")))
     if (!isTRUE(flag)) {
         msg <- sprintf("Entries in the `condition` argument must be element of: %s",
-                       paste(colnames(dat), collapse = ", "))
+                       toString(colnames(dat)))
         insight::format_error(msg)
     }
 
@@ -136,7 +136,7 @@ sanitize_condition <- function(model, condition, variables = NULL, modeldata = N
             }
         }
     }
-    
+
     # condition 4: facet_2
     if (length(condition) > 3) {
       if (is.null(condition[[4]])) {
@@ -156,7 +156,7 @@ sanitize_condition <- function(model, condition, variables = NULL, modeldata = N
 
     at_list[["model"]] <- model
     at_list[["newdata"]] <- dat
-    
+
     if (isTRUE(checkmate::check_list(variables))) {
         flag <- all(names(variables) %in% names(condition))
     } else {
@@ -176,7 +176,7 @@ sanitize_condition <- function(model, condition, variables = NULL, modeldata = N
     }
 
     # mlr3 and tidymodels are not supported by `insight::find_variables()`, so we need to create a grid based on all the variables supplied in `newdata`
-    if (inherits(at_list$model, "Learner") || 
+    if (inherits(at_list$model, "Learner") ||
         inherits(at_list$model, "model_fit") ||
         inherits(at_list$model, "workflow") ) {
         at_list$model <- NULL
@@ -187,13 +187,13 @@ sanitize_condition <- function(model, condition, variables = NULL, modeldata = N
 
     out <- list(
         "modeldata" = dat,
-        "newdata" = nd, 
+        "newdata" = nd,
         "resp" = resp,
         "respname" = respname,
-        "condition" = condition, 
-        "condition1" = condition1, 
-        "condition2" = condition2, 
+        "condition" = condition,
+        "condition1" = condition1,
+        "condition2" = condition2,
         "condition3" = condition3,
-        "condition4" = condition4) 
+        "condition4" = condition4)
     return(out)
 }

--- a/R/sanitize_numderiv.R
+++ b/R/sanitize_numderiv.R
@@ -9,14 +9,14 @@ sanitize_numderiv <- function(numderiv) {
     }
 
     if (length(numderiv) > 1) {
-        if (numderiv[[1]] %in% c("fdforward", "fdcenter")) {
-            if (!all(names(numderiv)[2:length(numderiv)] %in% "eps")) {
-                stop("The only valid argument for this numeric differentiation method is `eps`.")
+        if (numderiv[[1L]] %in% c("fdforward", "fdcenter")) {
+            if (!all(names(numderiv)[-1L] %in% "eps")) {
+                stop("The only valid argument for this numeric differentiation method is `eps`.", call. = FALSE)
             }
-        } else if (numderiv[[1]] == "richardson") {
+        } else if (numderiv[[1L]] == "richardson") {
             valid <- c("eps", "d", "zero_tol", "size", "r", "v")
-            if (!all(names(numderiv)[2:length(numderiv)] %in% valid)) {
-                stop(sprintf("The only valid arguments for this numeric differentiation method are: %s. See `?numDeriv::grad` for details.", paste(valid, collapse = ", ")), call. = FALSE)
+            if (!all(names(numderiv)[-1L] %in% valid)) {
+                stop(sprintf("The only valid arguments for this numeric differentiation method are: %s. See `?numDeriv::grad` for details.", toString(valid)), call. = FALSE)
             }
         }
     }

--- a/R/sanitize_reserved.R
+++ b/R/sanitize_reserved.R
@@ -21,7 +21,7 @@ sanity_reserved <- function(model = NULL, modeldata = data.frame()) {
     if (length(bad) > 0) {
         msg <- c(
             "These variable names are forbidden to avoid conflicts with the outputs of `marginaleffects`:",
-            sprintf("%s", paste(sprintf('"%s"', bad), collapse = ", ")),
+            toString(dQuote(bad, NULL)),
             "Please rename your variables before fitting the model.")
         insight::format_error(msg)
     }

--- a/R/sanitize_variables.R
+++ b/R/sanitize_variables.R
@@ -94,7 +94,7 @@ sanitize_variables <- function(variables,
   if (length(miss) > 0) {
     msg <- sprintf(
       "These variables were not found: %s.  Try specifying the `newdata` argument explicitly and make sure the missing variable is included.",
-      paste(miss, collapse = ", "))
+      toString(miss))
     insight::format_warning(msg)
   }
 
@@ -219,7 +219,7 @@ sanitize_variables <- function(variables,
         flag5 <- checkmate::check_data_frame(predictors[[v]])
         if (!isTRUE(flag1) && !isTRUE(flag2) && !isTRUE(flag3) && !isTRUE(flag4) && !isTRUE(flag5)) {
           msg <- "The %s element of the `variables` argument must be a vector of length 2 or one of: %s"
-          msg <- sprintf(msg, v, paste(valid, collapse = ", "))
+          msg <- sprintf(msg, v, toString(valid))
           insight::format_error(msg)
         }
       } else if (calling_function == "predictions") {
@@ -230,7 +230,7 @@ sanitize_variables <- function(variables,
               c("pairwise", "reference", "sequential", "revpairwise", "revreference", "revsequential"))
             if (length(invalid) > 0) {
               msg <- "These values are only supported by the `variables` argument in the `comparisons()` function: %s"
-              msg <- sprintf(msg, paste(invalid, collapse = ", "))
+              msg <- sprintf(msg, toString(invalid))
             } else {
               msg <- "Some elements of the `variables` argument are not in their original data. Check this variable: %s"
               msg <- sprintf(msg, v)

--- a/R/sanity_by.R
+++ b/R/sanity_by.R
@@ -21,7 +21,7 @@ sanity_by <- function(by, newdata) {
     }
 
     if (flag) {
-        bycols <- paste(setdiff(colnames(newdata), c("rowid", "rowidcf", "term", "group")), collapse = ", ")
+        bycols <- toString(setdiff(colnames(newdata), c("rowid", "rowidcf", "term", "group")))
         msg <- c(
             "The `by` argument must be either:", "",
             sprintf("1. Character vector in which each element is part of: %s", bycols),

--- a/R/sanity_dots.R
+++ b/R/sanity_dots.R
@@ -15,7 +15,7 @@ sanity_dots <- function(model, calling_function = NULL, ...) {
         if (length(unsupported) > 0) {
             msg <- sprintf(
                 "These arguments are supported by the `comparisons()` function but not by the `slopes()` function: %s",
-                paste(unsupported, collapse = ", "))
+                toString(unsupported))
             stop(msg, call. = FALSE)
         }
     }
@@ -78,11 +78,11 @@ sanity_dots <- function(model, calling_function = NULL, ...) {
         if (model_class %in% names(valid)) {
             msg <- sprintf(
                 "These arguments are not known to be supported for models of class `%s`: %s. These arguments are known to be valid: %s. All arguments are still passed to the model-specific prediction function, but users are encouraged to check if the argument is indeed supported by their modeling package. Please file a request on Github if you believe that an unknown argument should be added to the `marginaleffects` white list of known arguments, in order to avoid raising this warning: https://github.com/vincentarelbundock/marginaleffects/issues",
-                model_class, paste(bad, collapse = ", "), paste(valid[[model_class]], collapse = ", "))
+                model_class, toString(bad), toString(valid[[model_class]]))
         } else {
             msg <- sprintf(
                 "These arguments are not known to be supported for models of class `%s`: %s. All arguments are still passed to the model-specific prediction function, but users are encouraged to check if the argument is indeed supported by their modeling package. Please file a request on Github if you believe that an unknown argument should be added to the `marginaleffects` white list of known arguments, in order to avoid raising this warning: https://github.com/vincentarelbundock/marginaleffects/issues",
-                model_class, paste(bad, collapse = ", "))
+                model_class, toString(bad))
         }
         warning(msg, call. = FALSE)
     }

--- a/R/sanity_model.R
+++ b/R/sanity_model.R
@@ -126,7 +126,7 @@ sanity_model_supported_class <- function(model) {
         }
     }
     if (isFALSE(flag)) {
-        support <- paste(sort(unique(sapply(supported, function(x) x[1]))), collapse = ", ")
+        support <- toString(sort(unique(sapply(supported, function(x) x[1]))))
         msg <- c(
             sprintf('Models of class "%s" are not supported. Supported model classes include:', class(model)[1]),
             "",

--- a/R/utils.R
+++ b/R/utils.R
@@ -18,7 +18,9 @@ get_unique_index <- function(x, term_only = FALSE) {
 
     if (length(idx) == 0) {
         return(NULL)
-    } else if (length(idx) == 1) {
+    }
+
+    if (length(idx) == 1) {
         return(x[[idx]])
     }
 
@@ -30,7 +32,7 @@ get_unique_index <- function(x, term_only = FALSE) {
         }
     }
 
-    out <- apply(out, 1, paste, collapse = ", ")
+    out <- apply(out, 1, toString)
     return(out)
 }
 


### PR DESCRIPTION
I improved the printing when the output is split due to too many rows. Previously, the top and bottom wouldn't necessarily be aligned. Now they are. I also did some minor code cleaning (mostly replacing `paste(., collapse = ", ")` with the cleaner but equivalent `toString(.)`).