### PR TITLE
`vcov=` accepts `inferences()` methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ New:
 * The `hypothesis` argument can specify 1-tailed tests with strings: `avg_predictions(model, hypothesis = "b1 <= 3")`
 * `get_dataset()` no longer requires the user to specify the `package` argument. It automatically searches the data index for a unique matching dataset.
 * `hypotheses()` adds response names to term names. This allows `hypothesis="groupa_var1=groupb_var1"`. Thanks to @mattansb for report #1432.
+* `vcov` accepts "rsample", "boot", "fwb", and "simulation". The object is automatically passed to `inferences(method=)` with default arguments. This is only meant as a shortcut.  To customize the bootstrap strategy, users should use `inferences()`.
 
 Bugs:
 

--- a/R/comparisons.R
+++ b/R/comparisons.R
@@ -236,6 +236,14 @@ comparisons <- function(model,
 
   call_attr <- construct_call(model, "comparisons")
 
+  methods <- c("rsample", "boot", "fwb", "simulation")
+  if (isTRUE(checkmate::check_choice(vcov, methods))) {
+    inferences_method <- vcov
+    vcov <- FALSE
+  } else {
+    inferences_method <- NULL
+  }
+
   # multiple imputation
   if (inherits(model, c("mira", "amest"))) {
       out <- process_imputation(model, call_attr)
@@ -529,6 +537,11 @@ comparisons <- function(model,
   }
 
   class(out) <- c("comparisons", class(out))
+
+  if (!is.null(inferences_method)) {
+    out <- inferences(out, method = inferences_method)
+  }
+
   return(out)
 }
 

--- a/R/predictions.R
+++ b/R/predictions.R
@@ -189,6 +189,14 @@ predictions <- function(model,
                         numderiv = "fdforward",
                         ...) {
 
+  methods <- c("rsample", "boot", "fwb", "simulation")
+  if (isTRUE(checkmate::check_choice(vcov, methods))) {
+    inferences_method <- vcov
+    vcov <- FALSE
+  } else {
+    inferences_method <- NULL
+  }
+
   if ("cross" %in% ...names()) {
     insight::format_error("The `cross` argument is not available in this function.")
   }
@@ -540,6 +548,10 @@ predictions <- function(model,
     out$group <- NULL
   }
 
+  if (!is.null(inferences_method)) {
+    out <- inferences(out, method = inferences_method)
+  }
+
   return(out)
 }
 
@@ -635,7 +647,6 @@ get_predictions <- function(model,
   # otherwise, users cannot know for sure what is going to be the first and
   # second rows, etc.
   out <- sort_columns(out, newdata, by)
-
 
   return(out)
 }

--- a/R/slopes.R
+++ b/R/slopes.R
@@ -46,6 +46,8 @@
 #'    - Heteroskedasticity and autocorrelation consistent: `"HAC"`
 #'    - Mixed-Models degrees of freedom: "satterthwaite", "kenward-roger"
 #'    - Other: `"NeweyWest"`, `"KernHAC"`, `"OPG"`. See the `sandwich` package documentation.
+#'    - "rsample", "boot", "fwb", and "simulation" are passed to the `method` argument of the `inferences()` function. To customize the bootstrap or simulation process, call `inferences()` directly.
+#' 
 #'  * One-sided formula which indicates the name of cluster variables (e.g., `~unit_id`). This formula is passed to the `cluster` argument of the `sandwich::vcovCL` function.
 #'  * Square covariance matrix
 #'  * Function which returns a covariance matrix (e.g., `stats::vcov(model)`)


### PR DESCRIPTION
```r
pkgload::load_all()
mod <- lm(mpg ~ hp, mtcars)
p1 = predictions(mod, vcov = "rsample")
p2 = predictions(mod, vcov = "fwb")

p1 = avg_comparisons(mod, vcov = "rsample")
p1 = avg_comparisons(mod, vcov = "simulation")
p2 = avg_comparisons(mod, vcov = "fwb")
```