### PR TITLE
jax experiment

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -151,6 +151,7 @@ Suggests:
     rcmdcheck,
     remotes,
     reticulate,
+    reticulate,
     rmarkdown,
     rms,
     robust,
@@ -239,6 +240,7 @@ Collate:
     'inferences_fwb.R'
     'inferences_rsample.R'
     'inferences_simulation.R'
+    'jax.R'
     'matrix_apply.R'
     'mean_or_mode.R'
     'methods.R'

--- a/R/get_se_delta.R
+++ b/R/get_se_delta.R
@@ -98,6 +98,14 @@ get_se_delta <- function(
         coefs <- coefs[bnames]
     }
 
+    # get Jacobian for predictions using JAX
+    jax_flag <- isTRUE(getOption("jax", default = FALSE))
+    if (jax_flag) {
+        X <- attr(newdata, "marginaleffects_model_matrix")
+        # assigning a value to J immediately will skip the expensive computations below
+        J <- jacobian_jax_lm(X, coefs)
+    }
+
     # input: named vector of coefficients
     # output: gradient
     inner <- function(x) {

--- a/R/jax.R
+++ b/R/jax.R
@@ -1,0 +1,10 @@
+jacobian_jax_lm <- function(X, coefs) {
+    np_array <- numpy$array
+    get_predict_jax_lm <- function(coefs) {
+        X %*% coefs
+    }
+    f_jacobian <- jax$jacfwd(get_predict_jax_lm)
+    J <- f_jacobian(np_array(coefs))
+    J <- numpy$array(J)
+    return(J)
+}


### PR DESCRIPTION
@arcruz0 here’s a minimal integration of JAX in `predictions()`. I get about 2x speedup in one contrived example.

I think we should experiment with something like that to see if there’s real potential for massive gains. That will give us a good sense of whether this is worth the effort.

Right now, this only works for `predictions(mod)` without any argument, and only for `lm` models. Internally, we check if `getOption("jax")` is `TRUE` and if so, we use JAX to compute the Jacobian of the predictions.

If we want to make this more general, we would need to:

1.  Have a more rigorous way to tell `get_se_delta()` which specific calls are JAX-supported.
2.  Implement new functions like the one I put in `R/jax.R`.
3.  Add some safety checks to make sure the Python environment is properly configured and users get informative error messages.
4.  Maybe refactor the code to make it more like a “plugin” infrastructure.

``` r
library(microbenchmark)
library(marginaleffects)

insight::check_if_installed("reticulate")
numpy <<- reticulate::import("numpy")
jax <<- reticulate::import("jax")

N <- 100000
dat <- data.frame(
    y = rnorm(N),
    x1 = sample(letters, N, replace = TRUE),
    x2 = sample(letters, N, replace = TRUE),
    x3 = sample(letters, N, replace = TRUE)
)
mod <- lm(y ~ x1 + x2 + x3, data = dat)

p_jax <- function() {
    options(jax = TRUE)
    predictions(mod)
}
p_no_jax <- function() {
    options(jax = FALSE)
    predictions(mod)
}

a = p_jax()
b = p_no_jax()
all.equal(a$estimate, b$estimate)
#> [1] TRUE
all.equal(a$std.error, b$std.error)
#> [1] TRUE

microbenchmark(
    p_jax(),
    p_no_jax(),
    times = 25
)
#> Warning in microbenchmark(p_jax(), p_no_jax(), times = 25): less accurate
#> nanosecond times to avoid potential integer overflows
#> Unit: milliseconds
#>        expr      min       lq     mean   median       uq      max neval cld
#>     p_jax() 269.6382 276.2116 294.5163 284.4181 291.2288 350.8728    25  a 
#>  p_no_jax() 665.8196 678.2469 704.7367 692.8608 722.2983 782.5606    25   b
```
