### PR TITLE
Fixes to inferences()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: marginaleffects
 Title: Predictions, Comparisons, Slopes, Marginal Means, and Hypothesis Tests
-Version: 0.28.0.5
+Version: 0.28.0.6
 Authors@R:
     c(person(given = "Vincent",
              family = "Arel-Bundock",

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Better error message for bayesian/bootstrap models when `hypotheses()` attempts to post-process a previous `marginaleffects` call.
 * Model matrix is attached to more `newdata`. Useful for Issue #6 in `marginaleffectsJAX`.
 * Better error for unsupported custom classes with `inferences()`. Unfortunately, we cannot support them because they are not guaranteed to come with an appropriate `update()` class.
+* `inferences()` new computes p-values for `method = "fwb"`. `conf_type` can now be `"perc"` or `"wald"` for `method = "simulation"`.
 
 ## 0.28.0
 

--- a/R/inferences_boot.R
+++ b/R/inferences_boot.R
@@ -1,4 +1,6 @@
 inferences_boot <- function(x, R = 1000, conf_level = 0.95, conf_type = "perc", estimator = NULL, ...) {
+    insight::check_if_installed("boot")
+
     out <- x
     call_mfx <- attr(x, "call")
     call_mfx[["vcov"]] <- FALSE

--- a/R/inferences_rsample.R
+++ b/R/inferences_rsample.R
@@ -1,4 +1,6 @@
 inferences_rsample <- function(x, R = 1000, conf_level = 0.95, conf_type = "perc", estimator = NULL, ...) {
+    insight::check_if_installed("rsample")
+
     out <- x
     call_mfx <- attr(x, "call")
     call_mfx[["vcov"]] <- FALSE
@@ -33,10 +35,10 @@ inferences_rsample <- function(x, R = 1000, conf_level = 0.95, conf_type = "perc
         # This is a hack to avoid the issue of rsample::int_bca/pctl collapsing estimates when term is duplicated because of term/contrast/by unique
         # Warning: assumes that we always return estimates in the same order as the original {marginaleffects} call.
         # data.frame() to remove super heavy attributes (model, data, etc.)
-        # as.character() because `rsample` assumes character `term`. Reported here: 
+        # as.character() because `rsample` assumes character `term`. Reported here:
         # https://github.com/tidymodels/rsample/issues/574
         out <- data.frame(
-            term = as.character(seq_len(nrow(out))), 
+            term = as.character(seq_len(nrow(out))),
             estimate = out$estimate
         )
         return(out)

--- a/man/inferences.Rd
+++ b/man/inferences.Rd
@@ -36,9 +36,9 @@ inferences(
 \item{conf_type}{String: type of bootstrap interval to construct.
 \itemize{
 \item \code{boot}: "perc", "norm", "basic", or "bca"
-\item \code{fwb}: "perc", "norm", "basic", "bc", or "bca"
+\item \code{fwb}: "perc", "norm", "wald", "basic", "bc", or "bca"
 \item \code{rsample}: "perc" or "bca"
-\item \code{simulation}: argument ignored.
+\item \code{simulation}: "perc" or "wald"
 }}
 
 \item{conformal_test}{Data frame of test data for conformal prediction.}
@@ -51,12 +51,12 @@ inferences(
 \item "softmax" for classification tasks (when \code{predictions()} returns a \code{group} columns, such as multinomial or ordinal logit models.
 }}
 
-\item{estimator}{Function that accepts a data frame, fits a model, applies a marginaleffects function, and returns the object. Only supported with method="rsample" or method="boot". When method="rsample", the output must include a "term" column. This is not always the case for predictions(), in which case users may have to create the column manually.}
+\item{estimator}{Function that accepts a data frame, fits a model, applies a \code{marginaleffects} function, and returns the object. Only supported with \code{method = "rsample"} or \code{method = "boot"}. When \code{method = "rsample"}, the output must include a "term" column. This is not always the case for \code{predictions()}, in which case users may have to create the column manually.}
 
 \item{...}{\itemize{
-\item If \code{method="boot"}, additional arguments are passed to \code{boot::boot()}.
-\item If \code{method="fwb"}, additional arguments are passed to \code{fwb::fwb()}.
-\item If \code{method="rsample"}, additional arguments are passed to \code{rsample::bootstraps()}.
+\item If \code{method = "boot"}, additional arguments are passed to \code{boot::boot()}.
+\item If \code{method = "fwb"}, additional arguments are passed to \code{fwb::fwb()}.
+\item If \code{method = "rsample"}, additional arguments are passed to \code{rsample::bootstraps()}.
 \item Additional arguments are ignored for all other methods.
 }}
 }
@@ -69,14 +69,14 @@ Warning: This function is experimental. It may be renamed, the user interface ma
 Apply this function to a \code{marginaleffects} object to change the inferential method used to compute uncertainty estimates.
 }
 \details{
-When \code{method="simulation"}, we conduct simulation-based inference following the method discussed in Krinsky & Robb (1986):
+When \code{method = "simulation"}, we conduct simulation-based inference following the method discussed in Krinsky & Robb (1986):
 \enumerate{
 \item Draw \code{R} sets of simulated coefficients from a multivariate normal distribution with mean equal to the original model's estimated coefficients and variance equal to the model's variance-covariance matrix (classical, "HC3", or other).
 \item Use the \code{R} sets of coefficients to compute \code{R} sets of estimands: predictions, comparisons, slopes, or hypotheses.
-\item Take quantiles of the resulting distribution of estimands to obtain a confidence interval and the standard deviation of simulated estimates to estimate the standard error.
+\item Take quantiles of the resulting distribution of estimands to obtain a confidence interval (when \code{conf_type = "perc"}) and the standard deviation of simulated estimates to estimate the standard error (which is used for a Z-test and Wald confidence intervals when \code{conf_type = "wald"}).
 }
 
-When \code{method="fwb"}, drawn weights are supplied to the model fitting function's \code{weights} argument; if the model doesn't accept non-integer weights, this method should not be used. If weights were included in the original model fit, they are extracted by \code{\link[=weights]{weights()}} and multiplied by the drawn weights. These weights are supplied to the \code{wts} argument of the estimation function (e.g., \code{comparisons()}).
+When \code{method = "fwb"}, drawn weights are supplied to the model fitting function's \code{weights} argument; if the model doesn't accept non-integer weights, this method should not be used. If weights were included in the original model fit, they are extracted by \code{\link[=weights]{weights()}} and multiplied by the drawn weights. These weights are supplied to the \code{wts} argument of the estimation function (e.g., \code{comparisons()}).
 
 Warning: custom model classes are not supported by \code{inferences()} because they are not guaranteed to come with an appropriate \code{update()} method.
 }


### PR DESCRIPTION
Updating for new version of `fwb`. Fixed issue where dots were not passed to `fwb()`. Added p-values to fwb, as these are now produced by `summary.fwb()` by inverting CIs. Added `conf_type` to simulation, allowing for Wald inference (including p-values); default perc is unchanged. Minor cleaning here and there to improve organization.