### PR TITLE
Add support for single-level `multilevLCA::multiLCA()` models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -288,6 +288,7 @@ Collate:
     'methods_mlm.R'
     'methods_mlogit.R'
     'methods_mlr3.R'
+    'methods_multiLCA.R'
     'methods_nlme.R'
     'methods_ordinal.R'
     'methods_plm.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,10 @@
 * `autodiff()` now prints and returns the current state when called without arguments, so users can check whether autodiff is active without triggering any reticulate checks.
 * Raise a warning when `newdata` includes more than 100 columns, because this may lead to high memory use and computational load. We used to "prune" the internal datasets, but this let to many errors when `insight` did not fully support some models, or when using `by` and `hypothesis` in non-stardard ways. Thanks A.Tawfik for an email report.
 
+New:
+
+* Add support for structural part of single-level `multilevLCA::multiLCA()` models.
+
 Bugs:
 
 * Error when merging the original data back into `comparisons()` when the data includes some list columns. The problem is that `data.table` does not support that column type. We now return the original data.table error as a warning, and do not merge the data back. Thanks to @raffaem for report #1638.

--- a/R/methods_multiLCA.R
+++ b/R/methods_multiLCA.R
@@ -1,0 +1,140 @@
+#' @rdname get_coef
+#' @export
+get_coef.multiLCA <- function(model, ...) {
+  if (is.null(model$mGamma)) stop("multiLCA object has no mGamma. Fit with Z != NULL and extout = TRUE.")
+  b <- as.vector(model$mGamma)
+  if (!is.null(model$mV2) && !is.null(rownames(model$mV2))) {
+    names(b) <- rownames(model$mV2)
+  } else stop("Row names missing from object. Fit with Z != NULL and extout = TRUE.")
+  return(b)
+}
+
+
+#' @rdname set_coef
+#' @export
+set_coef.multiLCA <- function(model, coefs, ...) {
+  if (is.null(model$mGamma)) stop("multiLCA object has no mGamma. Fit with Z != NULL and extout = TRUE.")
+  P <- nrow(model$mGamma)
+  K <- ncol(model$mGamma)
+  if (!identical(length(coefs), P * K)) stop("Coefficient vector has wrong length for mGamma.")
+  model$mGamma <- matrix(unname(coefs), nrow = P, ncol = K, 
+                         dimnames = dimnames(model$mGamma))
+  return(model)
+}
+
+
+#' @rdname get_vcov
+#' @export
+get_vcov.multiLCA <- function(model, ...) {
+  if (!is.null(model$Varmat_cor) && 
+      isTRUE(as.character(model$estimator) == "Two-step")) return(model$Varmat_cor)
+  # One-step estimator does not require a variance correction as structural and 
+  # measurement models are fit at once
+  else if (!is.null(model$Varmat_unc) && 
+           isTRUE(as.character(model$estimator) == "One-step")) return(model$Varmat_unc)
+  else if (!is.null(model$Varmat)) return(model$Varmat)
+  else stop("No variance-covariance matrix found. Fit with extout = TRUE.")
+}
+
+
+.multiLCA_build_X <- function(newdata, terms) {
+  if(any(grepl("\\.", names(newdata)))) stop(
+    paste("multiLCA implementation requires variable names without periods.",
+          "Remove periods before fitting the LCA model.")
+  )
+  X <- matrix(NA_real_, nrow = nrow(newdata), ncol = length(terms))
+  colnames(X) <- terms
+  
+  for (j in seq_along(terms)) {
+    trm <- terms[j]
+    if (identical(trm, "Intercept")) {
+      X[, j] <- 1
+      next
+    }
+    # categorical terms
+    if (grepl("\\.", trm)) {
+      var <- sub("\\..*$", "", trm)
+      lvl <- sub("^[^.]*\\.", "", trm)
+      if (!var %in% names(newdata)) stop("Missing variable in newdata: ", var)
+      x <- newdata[[var]]
+      if (is.logical(x)) {
+        target <- if (lvl %in% c("TRUE", "FALSE")) (lvl == "TRUE") else as.logical(lvl)
+        X[, j] <- as.numeric(x == target)
+      } else {
+        X[, j] <- as.numeric(as.character(x) == lvl)
+      }
+      X[is.na(x), j] <- NA_real_
+      next
+    }
+    # numeric terms
+    if (!trm %in% names(newdata)) {
+      stop("Missing numeric covariate in newdata: ", trm)
+    }
+    x <- newdata[[trm]]
+    if (!is.numeric(x)) {
+      suppressWarnings(x_num <- as.numeric(as.character(x)))
+      if (any(!is.na(x) & is.na(x_num))) {
+        stop("Non-numeric values in covariate '", trm, "' cannot be coerced.")
+      }
+      x <- x_num
+    }
+    X[, j] <- x
+  }
+  return(X)
+}
+
+
+#' @rdname get_predict
+#' @export
+get_predict.multiLCA <- function(model, newdata, ...) {
+  # multiLCA does not have a predict() method
+  if (is.null(newdata)) stop("multiLCA prediction requires explicit newdata.")
+  newdata <- as.data.frame(newdata)
+  
+  G <- model$mGamma
+  nb_classes <- ncol(G) + 1L
+  class_labels <- colnames(model$mPhi)
+  
+  terms <- sub("^gamma\\(", "", sub("\\|C\\)$", "", rownames(G)))
+  B <- cbind(rep(0, nrow(G)), G)  
+  colnames(B) <- class_labels
+  rownames(B) <- terms
+  
+  vars <- unique(sub("\\..*$", "", terms))
+  vars <- setdiff(vars, "Intercept")
+  missing_vars <- setdiff(vars, names(newdata))
+  if (length(missing_vars) > 0) {
+    stop("Missing required covariates in newdata: ",
+         paste(missing_vars, collapse = ", "))
+  }
+  
+  # Create feature matrix from newdata and predict
+  X <- .multiLCA_build_X(newdata[, vars, drop = FALSE], terms)
+  eta <- X %*% B
+  # Numerically stable row-wise softmax
+  rw_mx <- apply(eta, 1, max)
+  exp_score <- exp(sweep(eta, 1, rw_mx, "-"))
+  probs <- exp_score / rowSums(exp_score)
+  
+  n <- nrow(probs)
+  out <- data.frame(
+    rowid    = rep(seq_len(n), times = nb_classes),
+    group    = rep(colnames(probs), each = n),
+    estimate = as.vector(probs),
+    row.names = NULL
+  )
+  out <- add_rowid(out, newdata)
+  return(out)
+}
+
+
+#' @rdname sanitize_model_specific
+#' @export
+sanitize_model_specific.multiLCA <- function(model, calling_function = NULL, ...) {
+  if (!is.null(calling_function) && 
+      !isTRUE(as.character(model$spec) == "Single-level LC model with covariates")) {
+    msg <- "Multi-level models are not yet supported for `multiLCA` objects."
+    stop_sprintf(msg)
+  }
+  return(model)
+}

--- a/R/sanity_model.R
+++ b/R/sanity_model.R
@@ -103,6 +103,7 @@ sanity_model_supported_class <- function(model, custom = TRUE) {
             "mira",
             "mlogit",
             "model_fit",
+            "multiLCA", # package: multilevLCA
             c("multinom", "nnet"),
             "multinom_weightit",
             "mvgam",

--- a/data-raw/supported_models.csv
+++ b/data-raw/supported_models.csv
@@ -57,6 +57,7 @@ mgcv,gam
 mhurdle,mhurdle
 mlogit,mlogit
 mlr3,Learner
+multilevLCA,multiLCA
 mvgam,mvgam
 mvgam,mvgam
 nlme,gls

--- a/inst/tinytest/test-pkg-multilevLCA.R
+++ b/inst/tinytest/test-pkg-multilevLCA.R
@@ -1,0 +1,39 @@
+using("marginaleffects")
+source("helpers.R")
+
+requiet("multilevLCA")
+
+# Single-level multiLCA model, three different estimators (no validity test)
+mlca_dat <- multilevLCA::dataTOY
+testY <- colnames(mlca_dat)[2:8]
+testZ <- c("Z_low", colnames(mlca_dat)[9:10])
+testvars <- c("Y_8", "Z_low")
+
+out_onestep = multiLCA(
+  mlca_dat, testY, 3, Z = testZ, fixedpars = 0, verbose = FALSE, extout = TRUE
+)
+expect_predictions(out_onestep, newdata = head(mlca_dat), variables = testvars)
+expect_comparisons(out_onestep, newdata = head(mlca_dat), variables = testvars)
+
+out_twostep = multiLCA(
+  mlca_dat, testY, 3, Z = testZ, fixedpars = 1, verbose = FALSE, extout = TRUE
+)
+expect_predictions(out_twostep, newdata = head(mlca_dat), variables = testvars)
+expect_comparisons(out_twostep, newdata = head(mlca_dat), variables = testvars)
+
+out_twostage = multiLCA(
+  mlca_dat, testY, 3, Z = testZ, fixedpars = 2, verbose = FALSE, extout = TRUE
+)
+expect_predictions(out_twostage, newdata = head(mlca_dat), variables = testvars)
+expect_comparisons(out_twostage, newdata = head(mlca_dat), variables = testvars)
+
+# rowid propagation
+nd_rowid <- head(mlca_dat, 3)
+nd_rowid$rowid <- c(101, 103, 102)
+pred_rowid <- predictions(out_onestep, newdata = nd_rowid)
+expect_equivalent(sort(unique(pred_rowid$rowid)), sort(nd_rowid$rowid))
+
+# class labels are consistent
+pred_groups <- unique(predictions(out_onestep, newdata = head(mlca_dat, 2))$group)
+expected_groups <- colnames(out_onestep$mPhi)
+expect_equivalent(sort(pred_groups), expected_groups)


### PR DESCRIPTION
This is an extension for partial support of [`multilevLCA::multiLCA()`](https://cran.r-universe.dev/multilevLCA/doc/manual.html) objects ([Lyrvall et al. 2024](https://arxiv.org/pdf/2305.07276)), which estimate single-level and multi-level measurement and structural latent class models (i.e., LCA with covariates). The structural portion is a regression model with latent classes as the outcome. There is no `predict()` method available to users, but coefficients and corrected variance-covariance matrices are exposed.

The specialized `get_predict` method is admittedly a little hacky here. Given the lack of a `predict()` method, it builds it manually and relies heavily on the current structure and format of the `multiLCA` objects (as of multilevLCA version 2.1.2) and may break if this output is changed in future releases, but I hope this can still be helpful!

The extension covers single-level models (all three estimators, i.e. one-step, two-step, and two-stage), but not multi-level ones. The output format is different in multi-level models, but it should not be too difficult to extend in the future for full support.

Included in this PR:
- S3 methods extension in `R/methods_multiLCA.R`
- Some minimal tests in `inst/test-pkg-multilevLCA.R`, but no validity ones (lacking a benchmark for now; particularly for standard errors in variance-corrected two-step estimation: [Bakk-Kuha 2018](https://www.cambridge.org/core/journals/psychometrika/article/abs/twostep-estimation-of-models-between-latent-classes-and-external-variables/B7DCF1428531715D9F8DEF6C9DA26B5F)
- Addition to list and vignette of supported models and a NEWS bulletpoint

Happy to make further changes as needed!