### PR TITLE
Replace `do.call()` with `safe_do_call()` to prevent console freeze on errors with large datasets

### DIFF
--- a/R/comparisons.R
+++ b/R/comparisons.R
@@ -338,7 +338,7 @@ comparisons <- function(
     )
     dots[["modeldata"]] <- NULL # dont' pass twice
     args <- utils::modifyList(args, dots)
-    contrast_data <- do.call("get_comparisons_data", args)
+    contrast_data <- safe_do_call(get_comparisons_data, args)
 
     # Add model matrices to hi/lo data
     contrast_data$hi <- add_model_matrix_attribute_data(mfx, contrast_data$hi)
@@ -455,7 +455,7 @@ comparisons <- function(
             hypothesis = mfx@hypothesis
         )
         args <- utils::modifyList(args, dots)
-        cmp <- do.call("get_comparisons", args)
+        cmp <- safe_do_call(get_comparisons, args)
 
         # hypothesis formula names are attached in by() in get_predictions()
         mfx@variable_names_by <- unique(c(
@@ -491,7 +491,7 @@ comparisons <- function(
                 numderiv = numderiv
             )
             args <- utils::modifyList(args, dots)
-            se <- do.call("get_se_delta", args)
+            se <- safe_do_call(get_se_delta, args)
             mfx@jacobian <- attr(se, "jacobian")
             cmp$std.error <- as.vector(as.numeric(se)) # drop attributes
             mfx@draws <- NULL

--- a/R/get_comparisons.R
+++ b/R/get_comparisons.R
@@ -439,7 +439,7 @@ compare_hi_lo <- function(hi, lo, y, n, term, cross, wts, tmp_idx, newdata, vari
     args[["x"]] <- elasticities[[tn]][tmp_idx]
 
     args <- args[names(args) %in% names(formals(fun))]
-    con <- try(do.call("fun", args), silent = TRUE)
+    con <- try(safe_do_call(fun, args), silent = TRUE)
 
     if (
         !isTRUE(checkmate::check_numeric(con, len = n)) &&

--- a/R/get_comparisons_data.R
+++ b/R/get_comparisons_data.R
@@ -57,7 +57,7 @@ get_comparisons_data <- function(
             stop(msg, call. = FALSE)
         }
 
-        tmp <- do.call(fun, args)
+        tmp <- safe_do_call(fun, args)
 
         lo[[v$name]] <- tmp$lo
         if (isTRUE(cross)) {

--- a/R/get_predict.R
+++ b/R/get_predict.R
@@ -66,7 +66,7 @@ get_predict.default <- function(
         pred <- dots[["pred"]]
     } else {
         fun <- stats::predict
-        pred <- suppressWarnings(do.call(fun, args))
+        pred <- suppressWarnings(safe_do_call(fun, args))
     }
 
     # 1-d array to vector (e.g., {mgcv})

--- a/R/get_se_delta.R
+++ b/R/get_se_delta.R
@@ -162,7 +162,7 @@ get_se_delta <- function(
             args$newparams <- x
         }
 
-        g <- do.call("FUN", args)
+        g <- safe_do_call(FUN, args)
 
         return(g)
     }

--- a/R/get_vcov.R
+++ b/R/get_vcov.R
@@ -28,7 +28,7 @@ get_vcov.default <- function(model, vcov = NULL, ...) {
     args[["component"]] <- "all"
 
     # 1st try: with arguments
-    out <- myTryCatch(do.call(get("get_varcov", asNamespace("insight")), args))
+    out <- myTryCatch(safe_do_call(get("get_varcov", asNamespace("insight")), args))
 
     # 2nd try: without arguments
     if (!isTRUE(checkmate::check_matrix(out$value, min.rows = 1))) {

--- a/R/hypotheses.R
+++ b/R/hypotheses.R
@@ -268,7 +268,7 @@ hypotheses <- function(
         if (...length() > 0) {
             args <- utils::modifyList(args, list(...))
         }
-        se <- do.call("get_se_delta", args)
+        se <- safe_do_call(get_se_delta, args)
         J <- attr(se, "jacobian")
         mfx@jacobian <- J
         attr(se, "jacobian") <- NULL

--- a/R/methods_betareg.R
+++ b/R/methods_betareg.R
@@ -59,7 +59,7 @@ get_predict.betareg <- function(model, newdata, type = "response", ...) {
         type = type
     )
     args[["at"]] <- dots[["at"]]
-    out <- do.call(stats::predict, args)
+    out <- safe_do_call(stats::predict, args)
     out <- data.table(estimate = out)
     out <- add_rowid(out, newdata)
     return(out)

--- a/R/methods_dbarts.R
+++ b/R/methods_dbarts.R
@@ -9,7 +9,7 @@ get_predict.bart <- function(model, newdata = NULL, ...) {
         ),
         list(...)
     )
-    p <- do.call(stats::predict, args)
+    p <- safe_do_call(stats::predict, args)
     p_med <- collapse::fmedian(p)
     out <- data.table(
         group = "main_marginaleffect",

--- a/R/methods_robustlmm.R
+++ b/R/methods_robustlmm.R
@@ -34,7 +34,7 @@ get_predict.rlmerMod <- function(
     args <- args[setdiff(names(args), unused)]
     args[["object"]] <- model
     args[["newdata"]] <- newdata
-    out <- data.table(estimate = do.call("predict", args))
+    out <- data.table(estimate = safe_do_call(stats::predict, args))
     out <- add_rowid(out, newdata)
     return(out)
 }

--- a/R/predictions.R
+++ b/R/predictions.R
@@ -394,7 +394,7 @@ predictions <- function(
         )
 
         args <- utils::modifyList(args, dots)
-        tmp <- do.call(get_predictions, args)
+        tmp <- safe_do_call(get_predictions, args)
 
         # hypothesis formula names are attached in by() in get_predictions()
         mfx@variable_names_by <- unique(c(
@@ -439,7 +439,7 @@ predictions <- function(
                     hypothesis = mfx@hypothesis
                 )
                 args <- utils::modifyList(args, dots)
-                se <- do.call(get_se_delta, args)
+                se <- safe_do_call(get_se_delta, args)
                 if (is.numeric(se) && length(se) == nrow(tmp)) {
                     mfx@jacobian <- attr(se, "jacobian")
                     tmp[["std.error"]] <- as.vector(se) # drop attribute

--- a/R/utils.R
+++ b/R/utils.R
@@ -196,3 +196,24 @@ warn_sprintf <- function(msg, ...) {
     }
     warning(msg, call. = FALSE)
 }
+
+
+# Like do.call() but avoids inlining argument values into the call expression.
+# When do.call(fn, list(huge_model, huge_data)) errors, R stores the entire
+# inlined data in sys.calls(), and IDEs (RStudio/Positron) try to deparse it,
+# causing multi-minute hangs. This builds a call with symbol references instead.
+# See: https://github.com/vincentarelbundock/marginaleffects/issues/1663
+safe_do_call <- function(what, args) {
+    call_env <- new.env(parent = parent.frame())
+    call_env[[".what"]] <- what
+    arg_names <- names(args) %||% rep("", length(args))
+    call_list <- vector("list", length(args) + 1L)
+    call_list[[1L]] <- as.symbol(".what")
+    for (i in seq_along(args)) {
+        sym_name <- sprintf(".arg%d", i)
+        call_env[[sym_name]] <- args[[i]]
+        call_list[[i + 1L]] <- as.symbol(sym_name)
+    }
+    names(call_list) <- c("", arg_names)
+    eval(as.call(call_list), call_env)
+}

--- a/man/comparisons.Rd
+++ b/man/comparisons.Rd
@@ -572,7 +572,10 @@ The \code{type} argument determines the scale of the predictions used to compute
 
 The \code{invlink(link)} is a special type defined by \code{marginaleffects}. It is available for some (but not all) models, and only for the \code{predictions()} function. With this link type, we first compute predictions on the link scale, then we use the inverse link function to backtransform the predictions to the response scale. This is useful for models with non-linear link functions as it can ensure that confidence intervals stay within desirable bounds, ex: 0 to 1 for a logit model. Note that an average of estimates with \code{type="invlink(link)"} will not always be equivalent to the average of estimates with \code{type="response"}. This type is default when calling \code{predictions()}. It is available---but not default---when calling \code{avg_predictions()} or \code{predictions()} with the \code{by} argument.
 
-Some of the most common \code{type} values are:\tabular{ll}{
+Some of the most common \code{type} values are:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{#> Warning: package 'tinytable' was built under R version 4.5.2
+}\if{html}{\out{</div>}}\tabular{ll}{
    class \tab type \cr
    DirichletRegModel \tab response \cr
    Gam \tab invlink(link), response, link \cr


### PR DESCRIPTION
## Summary

- Adds `safe_do_call()`, a drop-in replacement for `do.call()` that avoids inlining argument values into the call expression
- Replaces `do.call()` calls across the package with `safe_do_call()` wherever large objects are likely to be inlined

Fixes #1663

## Problem

When `do.call(fn, list(model, newdata))` errors, R stores the entire inlined data in `sys.calls()`. RStudio then deparses this call for `.Traceback` display, causing the console to hang for minutes after the error message has already been shown.

With 1M rows, the traceback reaches 275 MB and takes 12+ seconds just to deparse. With larger datasets this easily becomes 10+ minutes of unresponsiveness.

## Solution

`safe_do_call()` constructs a call using symbol references (`.what`, `.arg1`, `.arg2`, ...) bound in a temporary environment instead of inlining the actual objects. When an error occurs, `sys.calls()` contains only lightweight symbol references, so traceback deparsing is instant.

## Test plan

- [x] Verify `avg_predictions()` still works for `lm`, `glm`, `lmer`, `glmer` models
- [x] Verify error messages are still informative when predictions fail
- [x] Confirm console no longer hangs after errors with large datasets (e.g., 1M+ rows with `lmer`)
- [x] Run existing test suite
