### PR TITLE
Add vcov_unconditional(): standalone influence-function variance estimator

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -4,6 +4,7 @@
 
 New:
 
+* New `vcov_unconditional()` function computes standard errors using the influence-function approach of Hansen & Overgaard (2025, *Metrika*). This accounts for both parameter estimation uncertainty and the sampling variability of the averaging, providing robustness to model misspecification. Apply it to `avg_predictions()` or `avg_comparisons()` results. Supported for `lm` and `glm` models.
 * Support for `glmtoolbox::glmgee()` and `glmtoolbox::gnm()` models. Thanks to @luifrancgom for report #1148.
 * Support for `nestedLogit::nestedLogit()` models. Thanks to @strengejacke for report #1675.
 * Improved `type` error for `aft` models.

--- a/r/get_vcov_unconditional.R
+++ b/r/get_vcov_unconditional.R
@@ -1,0 +1,310 @@
+#' Unconditional (influence-function) variance for averaged predictions or
+#' comparisons
+#'
+#' Recomputes standard errors on a `marginaleffects` object using the
+#' influence-function approach of Hansen & Overgaard (2025, *Metrika*). This
+#' accounts for both parameter estimation uncertainty and the sampling
+#' variability of the covariate distribution, providing robustness to model
+#' misspecification.
+#'
+#' The function is self-contained: it reads the model, data, and structure from
+#' a finished `avg_predictions()` or `avg_comparisons()` result, computes the
+#' unconditional variance-covariance matrix, and returns the object with
+#' updated `std.error`, `statistic`, `p.value`, `s.value`, `conf.low`, and
+#' `conf.high` columns.
+#'
+#' @param x An object produced by `avg_predictions()` or `avg_comparisons()`.
+#'   The model must be `lm` or `glm`, and a single treatment variable
+#'   (`variables` argument) is required.
+#' @return A modified copy of `x` with unconditional standard errors and
+#'   recomputed test statistics and confidence intervals. The unconditional
+#'   variance-covariance matrix is stored in the `"marginaleffects"` attribute
+#'   and can be retrieved with `attr(x, "marginaleffects")@vcov_model`.
+#' @references
+#' Hansen SN, Overgaard M (2025). "Variance estimation for average treatment
+#' effects estimated by g-computation." *Metrika*, **88**, 419--443.
+#' \doi{10.1007/s00184-024-00962-4}
+#' @examples
+#' mod <- lm(mpg ~ am + hp + wt, data = mtcars)
+#' p <- avg_predictions(mod, variables = "am")
+#' vcov_unconditional(p)
+#'
+#' cmp <- avg_comparisons(mod, variables = "am")
+#' vcov_unconditional(cmp)
+#'
+vcov_unconditional <- function(x) {
+
+    # --- Extract and validate the marginaleffects object ---
+    mfx <- attr(x, "marginaleffects")
+    if (is.null(mfx)) {
+        marginaleffects:::stop_sprintf("vcov_unconditional() requires a marginaleffects object produced by avg_predictions() or avg_comparisons().")
+    }
+
+    model <- mfx@model
+    if (!class(model)[1] %in% c("lm", "glm")) {
+        marginaleffects:::stop_sprintf("vcov_unconditional() is only supported for lm and glm models.")
+    }
+
+    calling_function <- mfx@calling_function
+    if (!calling_function %in% c("predictions", "comparisons")) {
+        marginaleffects:::stop_sprintf("vcov_unconditional() only supports objects from avg_predictions() or avg_comparisons().")
+    }
+
+    if (length(mfx@variables) != 1) {
+        marginaleffects:::stop_sprintf("vcov_unconditional() requires a `variables` argument of length 1.")
+    }
+
+    if (!isTRUE(mfx@by) && !is.character(mfx@by)) {
+        marginaleffects:::stop_sprintf("vcov_unconditional() requires averaging over observations (e.g., avg_predictions() or avg_comparisons()).")
+    }
+
+    # Only support "difference" comparison for now
+    if (calling_function == "comparisons") {
+        cmp <- mfx@comparison
+        if (!is.null(cmp) && !identical(cmp, "difference") && !identical(cmp, "differenceavg")) {
+            marginaleffects:::stop_sprintf('vcov_unconditional() only supports comparison = "difference".')
+        }
+    }
+
+    insight::check_if_installed("sandwich")
+
+    modeldata <- mfx@modeldata
+    Y <- insight::get_response(model)
+    n <- length(Y)
+
+    trt_name <- mfx@variables[[1]]$name
+    trt_levels <- sort(unique(mfx@newdata[[trt_name]]))
+
+    # The influence function requires averaging over the same observations used
+    # to fit the model.  Detect when the user passed a custom `newdata`.
+    if (calling_function == "predictions") {
+        newdata_n <- nrow(mfx@newdata) / length(trt_levels)
+    } else {
+        newdata_n <- nrow(mfx@newdata)
+    }
+    if (newdata_n != n) {
+        marginaleffects:::stop_sprintf(
+            paste(
+                "vcov_unconditional() requires that predictions are computed on",
+                "the original model dataset (no custom `newdata`). The model was",
+                "fit on %d observations but the counterfactual grid implies %d."
+            ),
+            n, as.integer(newdata_n)
+        )
+    }
+    L <- length(trt_levels)
+    if (L < 2) {
+        marginaleffects:::stop_sprintf(
+            "vcov_unconditional() requires at least 2 levels in the treatment variable \"%s\".",
+            trt_name
+        )
+    }
+
+    fam <- if (inherits(model, "glm")) family(model) else NULL
+
+    # --- Determine subgroups from `by` ---
+    if (isTRUE(mfx@by)) {
+        group_var <- NULL
+    } else {
+        group_var <- setdiff(mfx@by, trt_name)
+        if (length(group_var) == 0) group_var <- NULL
+    }
+
+    by_vals <- NULL
+    group_levels <- NULL
+    num_groups <- 1L
+
+    if (!is.null(group_var)) {
+        if (length(group_var) > 1) {
+            marginaleffects:::stop_sprintf(
+                "vcov_unconditional() supports at most one grouping variable in `by`. Got: %s.",
+                paste(group_var, collapse = ", ")
+            )
+        }
+        if (calling_function == "predictions" && !trt_name %in% mfx@by) {
+            marginaleffects:::stop_sprintf(
+                'vcov_unconditional() for predictions with `by` requires the treatment variable "%s" in `by`.',
+                trt_name
+            )
+        }
+        by_vals <- modeldata[[group_var]]
+        if (is.null(by_vals)) {
+            marginaleffects:::stop_sprintf('`by` variable "%s" not found in the model data.', group_var)
+        }
+        group_levels <- sort(unique(by_vals))
+        num_groups <- length(group_levels)
+    }
+
+    # --- Contrast matrix for comparisons ---
+    # For avg_comparisons(), the estimand is Delta = C * Theta where C is a
+    # K x L contrast matrix.  The IF propagates linearly.
+    contrast_mat <- NULL
+    if (calling_function == "comparisons") {
+        K <- L - 1
+        contrast_mat <- matrix(0, nrow = K, ncol = L)
+        for (k in seq_len(K)) {
+            contrast_mat[k, 1] <- -1
+            contrast_mat[k, k + 1] <- 1
+        }
+    }
+
+    # --- Counterfactual predictions and gradients ---
+    # Hansen & Overgaard (2025), Eq. (4)
+    beta <- marginaleffects:::get_coef(model)
+    mu_hat <- matrix(NA_real_, nrow = n, ncol = L)
+    dmu_dbeta <- vector("list", L)
+
+    for (ell in seq_len(L)) {
+        cf_data <- modeldata
+        cf_data[[trt_name]] <- trt_levels[ell]
+
+        # Counterfactual data has treatment set to a constant, so
+        # model.matrix(model, ...) may fail on factor contrasts.  Fall back
+        # to terms-based construction when that happens.
+        MM_a <- tryCatch(
+            marginaleffects:::get_model_matrix(model, newdata = cf_data, mfx = mfx),
+            error = function(e) {
+                tryCatch(
+                    stats::model.matrix(
+                        stats::delete.response(stats::terms(model)),
+                        data = cf_data,
+                        xlev = model$xlevels
+                    ),
+                    error = function(e2) {
+                        marginaleffects:::stop_sprintf(
+                            "vcov_unconditional() failed to construct model matrix for intervention level \"%s\": %s",
+                            trt_levels[ell], e$message
+                        )
+                    }
+                )
+            }
+        )
+        if (is.null(MM_a)) {
+            marginaleffects:::stop_sprintf(
+                "vcov_unconditional() failed to construct model matrix for intervention level \"%s\".",
+                trt_levels[ell]
+            )
+        }
+
+        if (is.null(fam)) {
+            # lm: mu = X * beta
+            mu_hat[, ell] <- MM_a %*% beta
+            dmu_dbeta[[ell]] <- MM_a
+        } else {
+            # glm: mu = linkinv(X * beta + offset)
+            eta <- as.vector(MM_a %*% beta)
+
+            offset <- stats::model.offset(stats::model.frame(model))
+            if (!is.null(offset)) {
+                off_cf <- stats::model.offset(stats::model.frame(
+                    stats::delete.response(stats::terms(model)),
+                    data = cf_data
+                ))
+                if (is.null(off_cf)) {
+                    marginaleffects:::stop_sprintf(
+                        "vcov_unconditional() requires the offset variable to be present in the counterfactual data for intervention level \"%s\".",
+                        trt_levels[ell]
+                    )
+                }
+                eta <- eta + off_cf
+            }
+
+            mu_hat[, ell] <- fam$linkinv(eta)
+            mu_eta <- fam$mu.eta(eta)
+            dmu_dbeta[[ell]] <- MM_a * mu_eta
+        }
+    }
+
+    # --- Influence function for beta_hat ---
+    # Hansen & Overgaard (2025), Eq. (25)
+    psi <- sandwich::estfun(model)
+    bread_mat <- sandwich::bread(model)
+    beta_dot <- psi %*% bread_mat  # n x p
+
+    # --- Helper: influence-function contributions for a set of weights ---
+    compute_phi <- function(w_tilde) {
+        Theta <- colSums(w_tilde * mu_hat)
+        G_hat <- do.call(rbind, lapply(dmu_dbeta, function(D) colSums(w_tilde * D)))
+        mean_part <- sweep(mu_hat, 2, Theta, "-") * w_tilde
+        beta_part <- beta_dot %*% t(G_hat)
+        Phi <- mean_part + beta_part
+        if (!is.null(contrast_mat)) {
+            Phi <- Phi %*% t(contrast_mat)
+        }
+        Phi
+    }
+
+    # --- Compute variance ---
+    if (num_groups == 1L) {
+        # Full-sample: Hansen & Overgaard (2025), Eq. (8)
+        Phi <- compute_phi(rep(1 / n, n))
+        V <- crossprod(Phi) / n^2
+
+    } else {
+        # Subgroup estimation: Hansen & Overgaard (2025), Eq. (14)
+        Phi_list <- vector("list", num_groups)
+        for (g in seq_len(num_groups)) {
+            w <- as.numeric(by_vals == group_levels[g])
+            Phi_list[[g]] <- compute_phi(w / sum(w))
+        }
+
+        ncol_each <- ncol(Phi_list[[1]])
+
+        if (calling_function == "comparisons") {
+            Phi_full <- do.call(cbind, Phi_list)
+        } else {
+            trt_pos <- match(trt_name, mfx@by)
+            grp_pos <- match(group_var, mfx@by)
+            if (!is.na(trt_pos) && !is.na(grp_pos) && trt_pos < grp_pos) {
+                Phi_full <- matrix(0, nrow = n, ncol = ncol_each * num_groups)
+                col <- 0
+                for (ell in seq_len(ncol_each)) {
+                    for (g in seq_len(num_groups)) {
+                        col <- col + 1
+                        Phi_full[, col] <- Phi_list[[g]][, ell]
+                    }
+                }
+            } else {
+                Phi_full <- do.call(cbind, Phi_list)
+            }
+        }
+
+        V <- crossprod(Phi_full) / n^2
+    }
+
+    # --- Overwrite SEs and recompute test statistics / CIs ---
+    se <- sqrt(diag(V))
+    if (length(se) != nrow(x)) {
+        marginaleffects:::stop_sprintf(
+            "vcov_unconditional(): unconditional vcov has %d rows but the object has %d rows.",
+            length(se), nrow(x)
+        )
+    }
+    x$std.error <- se
+
+    # Recompute statistic, p.value, s.value, conf.low, conf.high
+    # Remove columns that get_ci_internal will recompute
+    x$statistic <- NULL
+    x$p.value <- NULL
+    x$s.value <- NULL
+    x$conf.low <- NULL
+    x$conf.high <- NULL
+
+    x <- marginaleffects:::get_ci_internal(
+        x,
+        conf_level = mfx@conf_level,
+        df = mfx@df,
+        draws = mfx@draws,
+        hypothesis_null = mfx@hypothesis_null,
+        hypothesis_direction = mfx@hypothesis_direction,
+        model = mfx@model
+    )
+
+    # Store the unconditional vcov on the internal object
+    mfx@vcov_model <- V
+    mfx@vcov_type <- "unconditional"
+    mfx@jacobian <- NULL
+    attr(x, "marginaleffects") <- mfx
+
+    x
+}

--- a/r/get_vcov_unconditional.R
+++ b/r/get_vcov_unconditional.R
@@ -33,52 +33,123 @@
 #' vcov_unconditional(cmp)
 #'
 vcov_unconditional <- function(x) {
+    inputs <- sanitize_unconditional(x)
+    V <- get_vcov_unconditional(inputs)
 
-    # --- Extract and validate the marginaleffects object ---
+    # --- Overwrite SEs and recompute test statistics / CIs ---
+    se <- sqrt(diag(V))
+    if (length(se) != nrow(x)) {
+        marginaleffects:::stop_sprintf(
+            "vcov_unconditional(): unconditional vcov has %d rows but the object has %d rows.",
+            length(se), nrow(x)
+        )
+    }
+    x$std.error <- se
+
+    x$statistic <- NULL
+    x$p.value <- NULL
+    x$s.value <- NULL
+    x$conf.low <- NULL
+    x$conf.high <- NULL
+
+    mfx <- inputs$mfx
+    x <- marginaleffects:::get_ci_internal(
+        x,
+        conf_level = mfx@conf_level,
+        df = mfx@df,
+        draws = mfx@draws,
+        hypothesis_null = mfx@hypothesis_null,
+        hypothesis_direction = mfx@hypothesis_direction,
+        model = mfx@model
+    )
+
+    mfx@vcov_model <- V
+    mfx@vcov_type <- "unconditional"
+    mfx@jacobian <- NULL
+    attr(x, "marginaleffects") <- mfx
+
+    x
+}
+
+
+#' Validate inputs for unconditional variance estimation
+#'
+#' Extracts the internal marginaleffects object, checks that the model class,
+#' calling function, variables, comparison type, and data dimensions are
+#' supported, and returns a named list of derived quantities needed by
+#' `get_vcov_unconditional()`.
+#'
+#' @param x An object produced by `avg_predictions()` or `avg_comparisons()`.
+#' @return A named list with components: `mfx`, `model`, `modeldata`, `n`,
+#'   `trt_name`, `trt_levels`, `L`, `fam`, `group_var`, `by_vals`,
+#'   `group_levels`, `num_groups`, `contrast_mat`.
+#' @noRd
+sanitize_unconditional <- function(x) {
     mfx <- attr(x, "marginaleffects")
     if (is.null(mfx)) {
-        marginaleffects:::stop_sprintf("vcov_unconditional() requires a marginaleffects object produced by avg_predictions() or avg_comparisons().")
+        marginaleffects:::stop_sprintf(
+            "vcov_unconditional() requires a marginaleffects object produced by avg_predictions() or avg_comparisons()."
+        )
     }
 
     model <- mfx@model
     if (!class(model)[1] %in% c("lm", "glm")) {
-        marginaleffects:::stop_sprintf("vcov_unconditional() is only supported for lm and glm models.")
+        marginaleffects:::stop_sprintf(
+            "vcov_unconditional() is only supported for lm and glm models. Got: \"%s\".",
+            class(model)[1]
+        )
     }
 
     calling_function <- mfx@calling_function
     if (!calling_function %in% c("predictions", "comparisons")) {
-        marginaleffects:::stop_sprintf("vcov_unconditional() only supports objects from avg_predictions() or avg_comparisons().")
+        marginaleffects:::stop_sprintf(
+            "vcov_unconditional() only supports objects from avg_predictions() or avg_comparisons(). Got: \"%s\".",
+            calling_function
+        )
     }
 
     if (length(mfx@variables) != 1) {
-        marginaleffects:::stop_sprintf("vcov_unconditional() requires a `variables` argument of length 1.")
+        marginaleffects:::stop_sprintf(
+            "vcov_unconditional() requires exactly one variable in the `variables` argument. Got %d.",
+            length(mfx@variables)
+        )
     }
 
     if (!isTRUE(mfx@by) && !is.character(mfx@by)) {
-        marginaleffects:::stop_sprintf("vcov_unconditional() requires averaging over observations (e.g., avg_predictions() or avg_comparisons()).")
+        marginaleffects:::stop_sprintf(
+            "vcov_unconditional() requires averaging over observations (e.g., avg_predictions() or avg_comparisons())."
+        )
     }
 
-    # Only support "difference" comparison for now
     if (calling_function == "comparisons") {
         cmp <- mfx@comparison
         if (!is.null(cmp) && !identical(cmp, "difference") && !identical(cmp, "differenceavg")) {
-            marginaleffects:::stop_sprintf('vcov_unconditional() only supports comparison = "difference".')
+            marginaleffects:::stop_sprintf(
+                'vcov_unconditional() only supports comparison = "difference". Got: "%s".',
+                as.character(cmp)
+            )
         }
     }
 
     insight::check_if_installed("sandwich")
 
     modeldata <- mfx@modeldata
-    Y <- insight::get_response(model)
-    n <- length(Y)
-
+    n <- length(insight::get_response(model))
     trt_name <- mfx@variables[[1]]$name
     trt_levels <- sort(unique(mfx@newdata[[trt_name]]))
+    L <- length(trt_levels)
 
-    # The influence function requires averaging over the same observations used
-    # to fit the model.  Detect when the user passed a custom `newdata`.
+    if (L < 2) {
+        marginaleffects:::stop_sprintf(
+            "vcov_unconditional() requires at least 2 levels in the treatment variable \"%s\". Got %d.",
+            trt_name, L
+        )
+    }
+
+    # Detect custom newdata: the counterfactual grid must cover the full
+    # training data.  predictions() expands to n*L rows; comparisons() keeps n.
     if (calling_function == "predictions") {
-        newdata_n <- nrow(mfx@newdata) / length(trt_levels)
+        newdata_n <- nrow(mfx@newdata) / L
     } else {
         newdata_n <- nrow(mfx@newdata)
     }
@@ -92,17 +163,8 @@ vcov_unconditional <- function(x) {
             n, as.integer(newdata_n)
         )
     }
-    L <- length(trt_levels)
-    if (L < 2) {
-        marginaleffects:::stop_sprintf(
-            "vcov_unconditional() requires at least 2 levels in the treatment variable \"%s\".",
-            trt_name
-        )
-    }
 
-    fam <- if (inherits(model, "glm")) family(model) else NULL
-
-    # --- Determine subgroups from `by` ---
+    # --- Subgroups from `by` ---
     if (isTRUE(mfx@by)) {
         group_var <- NULL
     } else {
@@ -129,15 +191,16 @@ vcov_unconditional <- function(x) {
         }
         by_vals <- modeldata[[group_var]]
         if (is.null(by_vals)) {
-            marginaleffects:::stop_sprintf('`by` variable "%s" not found in the model data.', group_var)
+            marginaleffects:::stop_sprintf(
+                'The `by` variable "%s" was not found in the model data.',
+                group_var
+            )
         }
         group_levels <- sort(unique(by_vals))
         num_groups <- length(group_levels)
     }
 
     # --- Contrast matrix for comparisons ---
-    # For avg_comparisons(), the estimand is Delta = C * Theta where C is a
-    # K x L contrast matrix.  The IF propagates linearly.
     contrast_mat <- NULL
     if (calling_function == "comparisons") {
         K <- L - 1
@@ -148,9 +211,57 @@ vcov_unconditional <- function(x) {
         }
     }
 
-    # --- Counterfactual predictions and gradients ---
-    # Hansen & Overgaard (2025), Eq. (4)
+    list(
+        mfx = mfx,
+        model = model,
+        modeldata = modeldata,
+        n = n,
+        calling_function = calling_function,
+        trt_name = trt_name,
+        trt_levels = trt_levels,
+        L = L,
+        fam = if (inherits(model, "glm")) family(model) else NULL,
+        group_var = group_var,
+        by_vals = by_vals,
+        group_levels = group_levels,
+        num_groups = num_groups,
+        contrast_mat = contrast_mat
+    )
+}
+
+
+#' Compute the unconditional variance-covariance matrix
+#'
+#' Pure computation: builds counterfactual predictions and their gradients,
+#' constructs the influence-function contributions, and returns the plug-in
+#' covariance matrix.  All validation is done upstream by
+#' `sanitize_unconditional()`.
+#'
+#' @param inputs Named list returned by `sanitize_unconditional()`.
+#' @return A square covariance matrix whose dimensions match the number of
+#'   output rows (L*G for predictions, K*G for comparisons).
+#' @references
+#' Hansen SN, Overgaard M (2025). Equation numbers refer to this paper.
+#' @noRd
+get_vcov_unconditional <- function(inputs) {
+    model        <- inputs$model
+    modeldata    <- inputs$modeldata
+    mfx          <- inputs$mfx
+    n            <- inputs$n
+    trt_name     <- inputs$trt_name
+    trt_levels   <- inputs$trt_levels
+    L            <- inputs$L
+    fam          <- inputs$fam
+    group_var    <- inputs$group_var
+    by_vals      <- inputs$by_vals
+    group_levels <- inputs$group_levels
+    num_groups   <- inputs$num_groups
+    contrast_mat <- inputs$contrast_mat
+    calling_function <- inputs$calling_function
+
     beta <- marginaleffects:::get_coef(model)
+
+    # --- Counterfactual predictions and gradients (Eq. 4) ---
     mu_hat <- matrix(NA_real_, nrow = n, ncol = L)
     dmu_dbeta <- vector("list", L)
 
@@ -158,9 +269,6 @@ vcov_unconditional <- function(x) {
         cf_data <- modeldata
         cf_data[[trt_name]] <- trt_levels[ell]
 
-        # Counterfactual data has treatment set to a constant, so
-        # model.matrix(model, ...) may fail on factor contrasts.  Fall back
-        # to terms-based construction when that happens.
         MM_a <- tryCatch(
             marginaleffects:::get_model_matrix(model, newdata = cf_data, mfx = mfx),
             error = function(e) {
@@ -172,7 +280,7 @@ vcov_unconditional <- function(x) {
                     ),
                     error = function(e2) {
                         marginaleffects:::stop_sprintf(
-                            "vcov_unconditional() failed to construct model matrix for intervention level \"%s\": %s",
+                            "Failed to construct model matrix for level \"%s\": %s",
                             trt_levels[ell], e$message
                         )
                     }
@@ -181,19 +289,16 @@ vcov_unconditional <- function(x) {
         )
         if (is.null(MM_a)) {
             marginaleffects:::stop_sprintf(
-                "vcov_unconditional() failed to construct model matrix for intervention level \"%s\".",
+                "Failed to construct model matrix for level \"%s\".",
                 trt_levels[ell]
             )
         }
 
         if (is.null(fam)) {
-            # lm: mu = X * beta
             mu_hat[, ell] <- MM_a %*% beta
             dmu_dbeta[[ell]] <- MM_a
         } else {
-            # glm: mu = linkinv(X * beta + offset)
             eta <- as.vector(MM_a %*% beta)
-
             offset <- stats::model.offset(stats::model.frame(model))
             if (!is.null(offset)) {
                 off_cf <- stats::model.offset(stats::model.frame(
@@ -202,109 +307,60 @@ vcov_unconditional <- function(x) {
                 ))
                 if (is.null(off_cf)) {
                     marginaleffects:::stop_sprintf(
-                        "vcov_unconditional() requires the offset variable to be present in the counterfactual data for intervention level \"%s\".",
+                        "Offset variable missing in counterfactual data for level \"%s\".",
                         trt_levels[ell]
                     )
                 }
                 eta <- eta + off_cf
             }
-
             mu_hat[, ell] <- fam$linkinv(eta)
-            mu_eta <- fam$mu.eta(eta)
-            dmu_dbeta[[ell]] <- MM_a * mu_eta
+            dmu_dbeta[[ell]] <- MM_a * fam$mu.eta(eta)
         }
     }
 
-    # --- Influence function for beta_hat ---
-    # Hansen & Overgaard (2025), Eq. (25)
-    psi <- sandwich::estfun(model)
-    bread_mat <- sandwich::bread(model)
-    beta_dot <- psi %*% bread_mat  # n x p
+    # --- Influence function for beta_hat (Eq. 25) ---
+    beta_dot <- sandwich::estfun(model) %*% sandwich::bread(model)
 
-    # --- Helper: influence-function contributions for a set of weights ---
+    # --- IF contributions for a given set of averaging weights ---
     compute_phi <- function(w_tilde) {
         Theta <- colSums(w_tilde * mu_hat)
         G_hat <- do.call(rbind, lapply(dmu_dbeta, function(D) colSums(w_tilde * D)))
-        mean_part <- sweep(mu_hat, 2, Theta, "-") * w_tilde
-        beta_part <- beta_dot %*% t(G_hat)
-        Phi <- mean_part + beta_part
-        if (!is.null(contrast_mat)) {
-            Phi <- Phi %*% t(contrast_mat)
-        }
+        Phi <- sweep(mu_hat, 2, Theta, "-") * w_tilde + beta_dot %*% t(G_hat)
+        if (!is.null(contrast_mat)) Phi <- Phi %*% t(contrast_mat)
         Phi
     }
 
-    # --- Compute variance ---
+    # --- Assemble variance (Eq. 8 or 14) ---
     if (num_groups == 1L) {
-        # Full-sample: Hansen & Overgaard (2025), Eq. (8)
         Phi <- compute_phi(rep(1 / n, n))
-        V <- crossprod(Phi) / n^2
+        return(crossprod(Phi) / n^2)
+    }
 
+    Phi_list <- lapply(seq_len(num_groups), function(g) {
+        w <- as.numeric(by_vals == group_levels[g])
+        compute_phi(w / sum(w))
+    })
+
+    ncol_each <- ncol(Phi_list[[1]])
+
+    if (calling_function == "comparisons") {
+        Phi_full <- do.call(cbind, Phi_list)
     } else {
-        # Subgroup estimation: Hansen & Overgaard (2025), Eq. (14)
-        Phi_list <- vector("list", num_groups)
-        for (g in seq_len(num_groups)) {
-            w <- as.numeric(by_vals == group_levels[g])
-            Phi_list[[g]] <- compute_phi(w / sum(w))
-        }
-
-        ncol_each <- ncol(Phi_list[[1]])
-
-        if (calling_function == "comparisons") {
-            Phi_full <- do.call(cbind, Phi_list)
-        } else {
-            trt_pos <- match(trt_name, mfx@by)
-            grp_pos <- match(group_var, mfx@by)
-            if (!is.na(trt_pos) && !is.na(grp_pos) && trt_pos < grp_pos) {
-                Phi_full <- matrix(0, nrow = n, ncol = ncol_each * num_groups)
-                col <- 0
-                for (ell in seq_len(ncol_each)) {
-                    for (g in seq_len(num_groups)) {
-                        col <- col + 1
-                        Phi_full[, col] <- Phi_list[[g]][, ell]
-                    }
+        trt_pos <- match(trt_name, mfx@by)
+        grp_pos <- match(group_var, mfx@by)
+        if (!is.na(trt_pos) && !is.na(grp_pos) && trt_pos < grp_pos) {
+            Phi_full <- matrix(0, nrow = n, ncol = ncol_each * num_groups)
+            col <- 0
+            for (ell in seq_len(ncol_each)) {
+                for (g in seq_len(num_groups)) {
+                    col <- col + 1
+                    Phi_full[, col] <- Phi_list[[g]][, ell]
                 }
-            } else {
-                Phi_full <- do.call(cbind, Phi_list)
             }
+        } else {
+            Phi_full <- do.call(cbind, Phi_list)
         }
-
-        V <- crossprod(Phi_full) / n^2
     }
 
-    # --- Overwrite SEs and recompute test statistics / CIs ---
-    se <- sqrt(diag(V))
-    if (length(se) != nrow(x)) {
-        marginaleffects:::stop_sprintf(
-            "vcov_unconditional(): unconditional vcov has %d rows but the object has %d rows.",
-            length(se), nrow(x)
-        )
-    }
-    x$std.error <- se
-
-    # Recompute statistic, p.value, s.value, conf.low, conf.high
-    # Remove columns that get_ci_internal will recompute
-    x$statistic <- NULL
-    x$p.value <- NULL
-    x$s.value <- NULL
-    x$conf.low <- NULL
-    x$conf.high <- NULL
-
-    x <- marginaleffects:::get_ci_internal(
-        x,
-        conf_level = mfx@conf_level,
-        df = mfx@df,
-        draws = mfx@draws,
-        hypothesis_null = mfx@hypothesis_null,
-        hypothesis_direction = mfx@hypothesis_direction,
-        model = mfx@model
-    )
-
-    # Store the unconditional vcov on the internal object
-    mfx@vcov_model <- V
-    mfx@vcov_type <- "unconditional"
-    mfx@jacobian <- NULL
-    attr(x, "marginaleffects") <- mfx
-
-    x
+    crossprod(Phi_full) / n^2
 }

--- a/r/man-roxygen/references.R
+++ b/r/man-roxygen/references.R
@@ -4,3 +4,4 @@
 #' * Arel-Bundock (2026). "Model to Meaning: How to interpret statistical models in R and Python." CRC Press. https://routledge.com/9781032908724
 #' * Greenland S. 2019. "Valid P-Values Behave Exactly as They Should: Some Misleading Criticisms of P-Values and Their Resolution With S-Values." The American Statistician. 73(S1): 106–114.
 #' * Cole, Stephen R, Jessie K Edwards, and Sander Greenland. 2020. "Surprise!" American Journal of Epidemiology 190 (2): 191–93. \doi{10.1093/aje/kwaa136}
+#' * Hansen SN, Overgaard M (2025). "Variance estimation for average treatment effects estimated by g-computation." _Metrika_, *88*, 419-443. \doi{10.1007/s00184-024-00962-4}

--- a/r/test-vcov-unconditional.R
+++ b/r/test-vcov-unconditional.R
@@ -1,0 +1,223 @@
+source("inst/tinytest/helpers.R")
+using("marginaleffects")
+source("get_vcov_unconditional.R")
+
+# ===========================================================================
+# vcov_unconditional(): influence-function variance estimator
+# Hansen & Overgaard (2025, Metrika)
+# ===========================================================================
+
+requiet("sandwich")
+
+# ---------------------------------------------------------------------------
+# GLM (logistic): validate against {beeca} reference values
+# ---------------------------------------------------------------------------
+if (requiet("beeca")) {
+    data01 <- trial01 |>
+        transform(trtp = as.factor(trtp)) |>
+        subset(!is.na(aval))
+    fit <- glm(aval ~ trtp + bl_cov, family = "binomial", data = data01)
+
+    # Reference from beeca::get_marginal_effect (Ye method)
+    ye <- get_marginal_effect(
+        object = fit, trt = "trtp", method = "Ye",
+        contrast = "diff", reference = "0")
+
+    # avg_comparisons then vcov_unconditional
+    cmp <- avg_comparisons(fit, variables = "trtp")
+    cmp_uncond <- vcov_unconditional(cmp)
+    expect_equivalent(cmp_uncond$estimate, ye$marginal_est, tolerance = 1e-6)
+    expect_equivalent(cmp_uncond$std.error, ye$marginal_se, tolerance = 0.01)
+
+    # avg_predictions then vcov_unconditional
+    pred <- avg_predictions(fit, variables = "trtp")
+    pred_uncond <- vcov_unconditional(pred)
+    expect_inherits(pred_uncond, "data.frame")
+    expect_true(nrow(pred_uncond) == 2)
+    expect_true(all(!is.na(pred_uncond$std.error)))
+}
+
+
+# ---------------------------------------------------------------------------
+# GLM (logistic): mtcars (always available)
+# ---------------------------------------------------------------------------
+dat <- mtcars
+dat$am <- as.factor(dat$am)
+mod <- glm(vs ~ am + hp + wt, family = binomial, data = dat)
+
+# avg_comparisons: unconditional SE should differ from default (delta method)
+cmp_delta <- avg_comparisons(mod, variables = "am")
+cmp_uncond <- vcov_unconditional(cmp_delta)
+expect_inherits(cmp_uncond, "data.frame")
+expect_true(nrow(cmp_uncond) == 1)
+expect_true(!is.na(cmp_uncond$std.error))
+# Estimates should be identical (same point estimate)
+expect_equivalent(cmp_delta$estimate, cmp_uncond$estimate, tolerance = 1e-10)
+# Standard errors should generally differ
+expect_true(abs(cmp_delta$std.error - cmp_uncond$std.error) > 1e-8)
+
+# avg_predictions: unconditional SE
+pred_delta <- avg_predictions(mod, variables = "am")
+pred_uncond <- vcov_unconditional(pred_delta)
+expect_inherits(pred_uncond, "data.frame")
+expect_true(nrow(pred_uncond) == 2)
+expect_true(all(!is.na(pred_uncond$std.error)))
+# Estimates should be identical
+expect_equivalent(pred_delta$estimate, pred_uncond$estimate, tolerance = 1e-10)
+
+
+# ---------------------------------------------------------------------------
+# LM: unconditional SE
+# ---------------------------------------------------------------------------
+mod_lm <- lm(mpg ~ am + hp + wt, data = mtcars)
+
+cmp_lm_delta <- avg_comparisons(mod_lm, variables = "am")
+cmp_lm_uncond <- vcov_unconditional(cmp_lm_delta)
+expect_inherits(cmp_lm_uncond, "data.frame")
+expect_true(nrow(cmp_lm_uncond) == 1)
+expect_true(!is.na(cmp_lm_uncond$std.error))
+expect_equivalent(cmp_lm_delta$estimate, cmp_lm_uncond$estimate, tolerance = 1e-10)
+
+pred_lm_delta <- avg_predictions(mod_lm, variables = "am")
+pred_lm_uncond <- vcov_unconditional(pred_lm_delta)
+expect_inherits(pred_lm_uncond, "data.frame")
+expect_true(nrow(pred_lm_uncond) == 2)
+expect_true(all(!is.na(pred_lm_uncond$std.error)))
+expect_equivalent(pred_lm_delta$estimate, pred_lm_uncond$estimate, tolerance = 1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Multi-level treatment (> 2 arms)
+# ---------------------------------------------------------------------------
+dat3 <- mtcars
+dat3$gear <- as.factor(dat3$gear)
+mod3 <- glm(vs ~ gear + hp + wt, family = binomial, data = dat3)
+
+# 3 levels: should produce 2 contrasts (4 vs 3, 5 vs 3)
+cmp3 <- vcov_unconditional(avg_comparisons(mod3, variables = "gear"))
+expect_inherits(cmp3, "data.frame")
+expect_true(nrow(cmp3) == 2)
+expect_true(all(!is.na(cmp3$std.error)))
+
+pred3 <- vcov_unconditional(avg_predictions(mod3, variables = "gear"))
+expect_inherits(pred3, "data.frame")
+expect_true(nrow(pred3) == 3)
+expect_true(all(!is.na(pred3$std.error)))
+
+
+# ---------------------------------------------------------------------------
+# Subgroup estimation: avg_comparisons with by = "group_var"
+# ---------------------------------------------------------------------------
+dat_by <- mtcars
+dat_by$am <- as.factor(dat_by$am)
+dat_by$vs <- as.factor(dat_by$vs)
+mod_by <- glm(mpg ~ am + vs + hp, data = dat_by)
+
+# avg_comparisons with by = "vs": ATE of am within each vs group
+cmp_by <- vcov_unconditional(avg_comparisons(mod_by, variables = "am", by = "vs"))
+expect_inherits(cmp_by, "data.frame")
+expect_true(nrow(cmp_by) == 2)
+expect_true(all(!is.na(cmp_by$std.error)))
+
+# Compare to overall ATE (no by): different SEs
+cmp_overall <- vcov_unconditional(avg_comparisons(mod_by, variables = "am"))
+expect_true(nrow(cmp_overall) == 1)
+# The by-group SEs should not match the overall SE
+expect_true(all(cmp_by$std.error != cmp_overall$std.error))
+
+# Point estimates should match delta method
+cmp_by_delta <- avg_comparisons(mod_by, variables = "am", by = "vs")
+expect_equivalent(cmp_by$estimate, cmp_by_delta$estimate, tolerance = 1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Subgroup estimation: avg_predictions with by = c(trt, group)
+# ---------------------------------------------------------------------------
+pred_by <- vcov_unconditional(
+    avg_predictions(mod_by, variables = "am", by = c("am", "vs")))
+expect_inherits(pred_by, "data.frame")
+expect_true(nrow(pred_by) == 4) # 2 am levels x 2 vs groups
+expect_true(all(!is.na(pred_by$std.error)))
+
+# Point estimates match delta method
+pred_by_delta <- avg_predictions(mod_by, variables = "am", by = c("am", "vs"))
+expect_equivalent(pred_by$estimate, pred_by_delta$estimate, tolerance = 1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Subgroup estimation: GLM (logistic) with by
+# ---------------------------------------------------------------------------
+dat_glm_by <- mtcars
+dat_glm_by$am <- as.factor(dat_glm_by$am)
+dat_glm_by$cyl <- as.factor(dat_glm_by$cyl)
+mod_glm_by <- glm(vs ~ am + cyl + hp, family = binomial, data = dat_glm_by)
+
+# ATE of am by cyl group
+cmp_glm_by <- vcov_unconditional(
+    avg_comparisons(mod_glm_by, variables = "am", by = "cyl"))
+expect_inherits(cmp_glm_by, "data.frame")
+expect_true(nrow(cmp_glm_by) == 3) # 3 cyl levels
+expect_true(all(!is.na(cmp_glm_by$std.error)))
+
+# Point estimates match delta method
+cmp_glm_by_delta <- avg_comparisons(mod_glm_by, variables = "am", by = "cyl")
+expect_equivalent(cmp_glm_by$estimate, cmp_glm_by_delta$estimate, tolerance = 1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Informative errors: unsupported model class
+# ---------------------------------------------------------------------------
+if (requiet("survival")) {
+    dat_surv <- survival::lung
+    dat_surv$sex <- as.factor(dat_surv$sex)
+    mod_cox <- survival::coxph(survival::Surv(time, status) ~ sex + age, data = dat_surv)
+    expect_error(
+        vcov_unconditional(avg_comparisons(mod_cox, variables = "sex")),
+        pattern = "only supported for lm and glm"
+    )
+}
+
+
+# ---------------------------------------------------------------------------
+# Informative errors: comparison != "difference"
+# ---------------------------------------------------------------------------
+expect_error(
+    vcov_unconditional(avg_comparisons(mod, variables = "am", comparison = "ratio")),
+    pattern = "only supports comparison"
+)
+
+expect_error(
+    vcov_unconditional(avg_comparisons(mod, variables = "am", comparison = "lnratio")),
+    pattern = "only supports comparison"
+)
+
+
+# ---------------------------------------------------------------------------
+# Informative errors: not a marginaleffects object
+# ---------------------------------------------------------------------------
+expect_error(
+    vcov_unconditional(data.frame(x = 1)),
+    pattern = "marginaleffects object"
+)
+
+
+# ---------------------------------------------------------------------------
+# Informative errors: custom newdata
+# ---------------------------------------------------------------------------
+expect_error(
+    vcov_unconditional(avg_predictions(mod, variables = "am", newdata = mtcars[1:10, ])),
+    pattern = "original model dataset"
+)
+
+
+# ---------------------------------------------------------------------------
+# CIs and test statistics are recomputed
+# ---------------------------------------------------------------------------
+cmp_orig <- avg_comparisons(mod, variables = "am")
+cmp_unc <- vcov_unconditional(cmp_orig)
+# conf.low and conf.high should exist and differ from original
+expect_true(all(c("conf.low", "conf.high", "statistic", "p.value") %in% names(cmp_unc)))
+expect_true(cmp_orig$conf.low != cmp_unc$conf.low)
+
+
+rm(list = ls())


### PR DESCRIPTION
Implements Hansen & Overgaard (2025, Metrika) unconditional variance for avg_predictions() and avg_comparisons() results. Accounts for both parameter estimation uncertainty and sampling variability of the covariate distribution, unlike the standard delta method which treats covariates as fixed.

The function is standalone (not wired into the marginaleffects pipeline): it takes a finished marginaleffects object, validates the structure, computes the influence-function vcov, and overwrites std.error/CI/p-values. Uses marginaleffects::: for internal accessors.

Supports: lm/glm models, multi-level treatments, subgroup estimation via `by`. Errors on custom `newdata` (subset/ATT not yet supported).

Validated against the {beeca} package (Ye method) for logistic regression.

Ref: issue #1240