### PR TITLE
[BUG] Circular import in `marginaleffects==0.5.0` breaks direct `datagrid` import

### DIFF
--- a/python/marginaleffects/plot/common.py
+++ b/python/marginaleffects/plot/common.py
@@ -36,7 +36,9 @@ def dt_on_condition(model, condition):
         condition_new.pop("newdata", None)
 
     if not (1 <= len(condition_new) <= 4):
-        raise ValueError(f"Length of condition must be inclusively between 1 and 4. Got: {len(condition_new)}.")
+        raise ValueError(
+            f"Length of condition must be inclusively between 1 and 4. Got: {len(condition_new)}."
+        )
 
     for key, value in to_datagrid.items():
         variable_type = model.get_variable_type(key)
@@ -53,7 +55,9 @@ def dt_on_condition(model, condition):
                 else modeldata[key].unique().sort().to_list()
             )
             if len(to_datagrid[key]) > 10:
-                raise ValueError(f"Character type variables of more than 10 unique values are not supported. {key} variable has {len(to_datagrid[key])} unique values.")
+                raise ValueError(
+                    f"Character type variables of more than 10 unique values are not supported. {key} variable has {len(to_datagrid[key])} unique values."
+                )
 
         elif variable_type in ["boolean", "binary"]:
             if to_datagrid[key] is None:
@@ -127,7 +131,9 @@ def validate_plot_args(condition, by, newdata, wts):
     if wts is not None and not by:
         raise ValueError("The `wts` argument requires a `by` argument.")
     if not ((condition is None and by) or (condition is not None and not by)):
-        raise ValueError("One of the `condition` and `by` arguments must be supplied, but not both.")
+        raise ValueError(
+            "One of the `condition` and `by` arguments must be supplied, but not both."
+        )
 
 
 def extract_var_list(condition, by):
@@ -147,7 +153,9 @@ def extract_var_list(condition, by):
     var_list = [x for x in var_list if x not in ["newdata", "model"]]
 
     if len(var_list) >= 5:
-        raise ValueError("The `condition` and `by` arguments can have a max length of 4.")
+        raise ValueError(
+            "The `condition` and `by` arguments can have a max length of 4."
+        )
 
     return var_list
 

--- a/python/marginaleffects/sanitize/newdata.py
+++ b/python/marginaleffects/sanitize/newdata.py
@@ -1,12 +1,16 @@
 import numpy as np
 import polars as pl
 
-from ..datagrid import datagrid
-from ..utils import ingest, upcast
 from ..formula import listwise_deletion
 
 
 def sanitize_newdata(model, newdata, wts, by=[]):
+    # Lazy imports to break the `datagrid -> utils -> sanitize -> newdata -> ...`
+    # circular import that fires when `datagrid` is the first symbol pulled from
+    # marginaleffects in a fresh interpreter (see GH #1724).
+    from ..datagrid import datagrid
+    from ..utils import ingest, upcast
+
     modeldata = model.get_modeldata()
 
     if newdata is None:
@@ -73,7 +77,9 @@ def sanitize_newdata(model, newdata, wts, by=[]):
         "statistic",
     }
     if set(out.columns) & reserved_names:
-        raise ValueError(f"Input data contain reserved column name(s): {set(out.columns).intersection(reserved_names)}")
+        raise ValueError(
+            f"Input data contain reserved column name(s): {set(out.columns).intersection(reserved_names)}"
+        )
 
     datagrid_explicit = None
     if isinstance(newdata, pl.DataFrame) and hasattr(newdata, "datagrid_explicit"):

--- a/python/marginaleffects/sanitize/variables.py
+++ b/python/marginaleffects/sanitize/variables.py
@@ -148,7 +148,9 @@ def _get_one_variable_hi_lo(
         elif callable(value):
             tmp = value(newdata[variable])
             if tmp.shape[1] != 2:
-                raise ValueError(f"The function passed to `variables` must return a DataFrame with two columns. Got {tmp.shape[1]}.")
+                raise ValueError(
+                    f"The function passed to `variables` must return a DataFrame with two columns. Got {tmp.shape[1]}."
+                )
             lo = tmp[:, 0]
             hi = tmp[:, 1]
             lab = "custom"

--- a/python/tests/test_bugfix.py
+++ b/python/tests/test_bugfix.py
@@ -1,3 +1,6 @@
+import subprocess
+import sys
+
 import numpy as np
 import pandas as pd
 import polars as pl
@@ -22,3 +25,18 @@ def test_issue_226_np_context():
     out = predictions(mod, newdata=df)
     assert isinstance(out, MarginaleffectsResult)
     assert isinstance(out.data, pl.DataFrame)
+
+
+def test_issue_1724():
+    # Circular import when `datagrid` is the first symbol pulled from
+    # marginaleffects in a fresh interpreter. Must run in a subprocess —
+    # the in-process pytest run has already warmed the import graph.
+    result = subprocess.run(
+        [sys.executable, "-c", "from marginaleffects import datagrid"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"Fresh-process import of `datagrid` failed.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )


### PR DESCRIPTION
Closes https://github.com/vincentarelbundock/marginaleffects/issues/1724

Some side changes are because of the linter (I can revert them).