### PR TITLE
Support statsmodels Nominal/Ordinal GEE in predictions/comparisons/slopes

### DIFF
--- a/python/marginaleffects/statsmodels/model.py
+++ b/python/marginaleffects/statsmodels/model.py
@@ -10,6 +10,15 @@ from ..sanitize.utils import validate_types
 
 
 class ModelStatsmodels(ModelAbstract):
+    # A few statsmodels models store coefficients in an expanded multi-equation
+    # form whose own `predict` cannot consume an ordinary (n, k) design matrix.
+    # Map the model class name to a method that reconstructs predictions from
+    # the plain design; every other model delegates to its native `predict`.
+    _PREDICT_RECONSTRUCTORS = {
+        "NominalGEE": "_predict_nominal_gee",
+        "OrdinalGEE": "_predict_ordinal_gee",
+    }
+
     def __init__(self, model, vault=None):
         if vault is None:
             vault = ModelVault()
@@ -110,6 +119,76 @@ class ModelStatsmodels(ModelAbstract):
     def _is_ordered_model(self):
         return "OrderedModel" in type(self.model.model).__name__
 
+    def _predict_array(self, params, exog):
+        """Predicted values as a numpy array from a plain (n, k) design.
+
+        Delegates to the model's native ``predict`` unless the model class is
+        registered in ``_PREDICT_RECONSTRUCTORS`` (multi-equation models whose
+        native ``predict`` cannot consume an ordinary design matrix).
+        """
+        reconstruct = self._PREDICT_RECONSTRUCTORS.get(type(self.model.model).__name__)
+        if reconstruct is not None:
+            return getattr(self, reconstruct)(params, exog)
+        return self.model.model.predict(params, exog)
+
+    def _predict_nominal_gee(self, params, exog):
+        """Category probabilities for a NominalGEE from an (n, k) design.
+
+        statsmodels stores NominalGEE in an expanded (long) form: each
+        observation is replicated ``ncut = n_categories - 1`` times and the
+        design is Kronecker-expanded, so the flat coefficient vector has
+        length ``ncut * k``. The model's inherited GLM ``predict`` only works
+        on that expanded matrix, so we rebuild category probabilities from the
+        ordinary ``(n, k)`` design via the multinomial-logit inverse link.
+        """
+        ncut = self.model.model.ncut
+        beta = np.asarray(params).ravel().reshape(ncut, -1)  # (ncut, k)
+        eta = np.asarray(exog) @ beta.T  # (n, ncut) per-cut linear predictors
+        expo = np.exp(eta)
+        denom = 1.0 + expo.sum(axis=1, keepdims=True)
+        # Sorted-category order: the `ncut` non-reference categories followed
+        # by the reference (largest) category, matching MNLogit's group order.
+        return np.column_stack([expo / denom, 1.0 / denom])
+
+    def _predict_ordinal_gee(self, params, exog):
+        """Category probabilities for an OrdinalGEE from an (n, k) design.
+
+        OrdinalGEE fits a cumulative-logit model: ``ncut = n_categories - 1``
+        threshold intercepts plus covariate slopes shared across thresholds,
+        modelling the survival probabilities ``P(Y > c_j)``. statsmodels stores
+        this in an expanded form whose inherited GLM ``predict`` cannot consume
+        an ordinary ``(n, k)`` design, so we rebuild the cumulative
+        probabilities ourselves.
+        """
+        from scipy.special import expit
+
+        # A model intercept is collinear with the threshold intercepts, which
+        # produces a rank-deficient fit with ~1e15 coefficients and unstable
+        # predictions. statsmodels' own examples fit without an intercept.
+        if "Intercept" in [str(n) for n in self.get_coefnames()]:
+            raise ValueError(
+                "OrdinalGEE was fit with a model intercept that is collinear "
+                "with the cumulative-link thresholds, producing a rank-"
+                "deficient fit with unstable coefficients. Refit without an "
+                'intercept, e.g. `smf.ordinal_gee("y ~ 0 + x1 + x2", ...)`.'
+            )
+
+        ncut = len(self.model.model.endog_values) - 1
+        params = np.asarray(params).ravel()
+        alpha = params[:ncut]  # threshold intercepts (decreasing in j)
+        beta = params[ncut:]  # covariate slopes, shared across thresholds
+        # Survival probabilities P(Y > c_j) for the ncut ordered thresholds.
+        surv = expit(alpha[None, :] + (np.asarray(exog) @ beta)[:, None])
+        # Successive survival differences give category probabilities, in
+        # sorted-category order to match the group labelling used elsewhere.
+        n = surv.shape[0]
+        probs = np.empty((n, ncut + 1))
+        probs[:, 0] = 1.0 - surv[:, 0]
+        for k in range(1, ncut):
+            probs[:, k] = surv[:, k - 1] - surv[:, k]
+        probs[:, ncut] = surv[:, ncut - 1]
+        return probs
+
     def get_predict(self, params, newdata: pl.DataFrame):
         if isinstance(newdata, np.ndarray):
             exog = newdata
@@ -123,7 +202,7 @@ class ModelStatsmodels(ModelAbstract):
         if self._is_ordered_model() and isinstance(exog, np.ndarray):
             if exog.shape[1] == self.model.model.k_vars + 1:
                 exog = exog[:, 1:]
-        p = self.model.model.predict(params, exog)
+        p = self._predict_array(params, exog)
         if p.ndim == 1:
             p = pl.DataFrame({"rowid": range(newdata.shape[0]), "estimate": p})
         elif p.ndim == 2:

--- a/python/tests/test_statsmodels_nominal_gee.py
+++ b/python/tests/test_statsmodels_nominal_gee.py
@@ -1,0 +1,92 @@
+import numpy as np
+import pandas as pd
+import polars as pl
+import pytest
+import statsmodels.formula.api as smf
+
+from marginaleffects import (
+    avg_comparisons,
+    avg_predictions,
+    avg_slopes,
+    predictions,
+    slopes,
+)
+
+
+def _make_data(seed=42, n_groups=60, group_size=6):
+    """Clustered data with a 3-category outcome that depends on x and z."""
+    rng = np.random.default_rng(seed)
+    rows = []
+    for g in range(n_groups):
+        x = rng.normal(size=group_size)
+        z = rng.integers(0, 2, size=group_size)
+        eta = np.column_stack([np.zeros(group_size), 0.9 * x, -0.7 * x + 0.6 * z])
+        p = np.exp(eta)
+        p /= p.sum(axis=1, keepdims=True)
+        cat = np.array([rng.choice(3, p=p[i]) for i in range(group_size)])
+        for i in range(group_size):
+            rows.append({"cat": int(cat[i]), "x": x[i], "z": z[i], "gid": g})
+    return pd.DataFrame(rows)
+
+
+dat = _make_data()
+mod = smf.nominal_gee("cat ~ x + z", "gid", dat).fit()
+ncat = len(mod.model.endog_values)  # 3
+ncut = mod.model.ncut  # 2
+
+
+def test_predictions_match_statsmodels_fitted():
+    # Predicted category probabilities must reproduce statsmodels' own fitted
+    # per-cut means (its independent computation of the multinomial mean).
+    pred = pl.DataFrame(predictions(mod))
+    mat = (
+        pred.select(["rowid", "group", "estimate"])
+        .pivot(values="estimate", index="rowid", on="group")
+        .sort("rowid")
+    )
+    me_cuts = mat.select([str(j) for j in range(ncut)]).to_numpy()
+    sm_fitted = np.asarray(mod.fittedvalues).reshape(dat.shape[0], ncut)
+    np.testing.assert_allclose(me_cuts, sm_fitted, atol=1e-8)
+
+    # Probabilities over all categories sum to 1 for every row.
+    all_probs = mat.select([str(j) for j in range(ncat)]).to_numpy()
+    np.testing.assert_allclose(all_probs.sum(axis=1), 1.0, atol=1e-8)
+
+
+def test_predictions_shape_and_groups():
+    pred = pl.DataFrame(predictions(mod))
+    assert pred.height == dat.shape[0] * ncat
+    assert sorted(pred["group"].unique().to_list()) == [str(j) for j in range(ncat)]
+    assert pred["estimate"].is_finite().all()
+
+
+def test_avg_predictions_by_group():
+    out = avg_predictions(mod, by="group")
+    assert out.height == ncat
+    # Average predicted probabilities over groups sum to 1.
+    assert out["estimate"].sum() == pytest.approx(1.0, abs=1e-6)
+    assert out["std_error"].is_finite().all()
+    assert (out["std_error"] > 0).all()
+
+
+def test_slopes_sum_to_zero_over_groups():
+    # On the probability simplex the marginal effect of any predictor sums to
+    # zero across categories; the delta-method SEs must be finite.
+    out = avg_slopes(mod)
+    assert out["std_error"].is_finite().all()
+    by_term = out.group_by("term").agg(pl.col("estimate").sum())
+    for s in by_term["estimate"].to_list():
+        assert s == pytest.approx(0.0, abs=1e-6)
+
+
+def test_avg_comparisons_runs():
+    out = avg_comparisons(mod, variables="x")
+    assert out.height == ncat
+    assert out["estimate"].sum() == pytest.approx(0.0, abs=1e-6)
+    assert out["std_error"].is_finite().all()
+
+
+def test_unit_level_slopes_run():
+    out = slopes(mod, variables="x")
+    assert out.height == dat.shape[0] * ncat
+    assert out["estimate"].is_finite().all()

--- a/python/tests/test_statsmodels_ordinal_gee.py
+++ b/python/tests/test_statsmodels_ordinal_gee.py
@@ -1,0 +1,112 @@
+import numpy as np
+import pandas as pd
+import polars as pl
+import pytest
+import statsmodels.api as sm
+import statsmodels.formula.api as smf
+
+from marginaleffects import (
+    avg_comparisons,
+    avg_predictions,
+    avg_slopes,
+    predictions,
+    slopes,
+)
+
+
+def _make_data(seed=0, n_groups=120, group_size=6):
+    """Clustered data with an ordered 4-category outcome."""
+    rng = np.random.default_rng(seed)
+    thresholds = np.array([-1.0, 0.0, 1.0])
+    rows = []
+    for g in range(n_groups):
+        x = rng.normal(size=group_size)
+        z = rng.integers(0, 2, size=group_size)
+        latent = 0.9 * x + 0.5 * z + rng.normal(size=group_size)
+        cat = (latent[:, None] > thresholds[None, :]).sum(axis=1)
+        for i in range(group_size):
+            rows.append({"cat": int(cat[i]), "x": x[i], "z": z[i], "gid": g})
+    return pd.DataFrame(rows)
+
+
+dat = _make_data()
+gor = sm.cov_struct.GlobalOddsRatio("ordinal")
+# Ordinal GEE must be fit WITHOUT a model intercept: the cumulative-link
+# thresholds already play that role (statsmodels' own example does this).
+mod = smf.ordinal_gee("cat ~ 0 + x + z", "gid", dat, cov_struct=gor).fit()
+ncat = len(mod.model.endog_values)  # 4
+ncut = ncat - 1  # 3
+
+
+def test_predictions_match_statsmodels_survival():
+    # The reconstructed category probabilities must imply the same survival
+    # probabilities P(Y > c_j) that statsmodels fits for each threshold.
+    pred = pl.DataFrame(predictions(mod))
+    mat = (
+        pred.select(["rowid", "group", "estimate"])
+        .pivot(values="estimate", index="rowid", on="group")
+        .sort("rowid")
+    )
+    probs = mat.select([str(j) for j in range(ncat)]).to_numpy()
+    # P(Y > c_j) = sum of probabilities for categories strictly above j.
+    surv_me = np.cumsum(probs[:, ::-1], axis=1)[:, ::-1][:, 1:]
+    sm_fitted = np.asarray(mod.fittedvalues).reshape(dat.shape[0], ncut)
+    np.testing.assert_allclose(surv_me, sm_fitted, atol=1e-8)
+
+    # Probabilities over all categories sum to 1 for every row.
+    np.testing.assert_allclose(probs.sum(axis=1), 1.0, atol=1e-8)
+
+
+def test_predictions_shape_and_groups():
+    pred = pl.DataFrame(predictions(mod))
+    assert pred.height == dat.shape[0] * ncat
+    assert sorted(pred["group"].unique().to_list()) == [str(j) for j in range(ncat)]
+    assert pred["estimate"].is_finite().all()
+
+
+def test_avg_predictions_by_group():
+    out = avg_predictions(mod, by="group")
+    assert out.height == ncat
+    assert out["estimate"].sum() == pytest.approx(1.0, abs=1e-6)
+    assert out["std_error"].is_finite().all()
+    assert (out["std_error"] > 0).all()
+
+
+def test_slopes_sum_to_zero_over_groups():
+    # The marginal effect of a predictor sums to zero across categories.
+    out = avg_slopes(mod)
+    assert out["std_error"].is_finite().all()
+    by_term = out.group_by("term").agg(pl.col("estimate").sum())
+    for s in by_term["estimate"].to_list():
+        assert s == pytest.approx(0.0, abs=1e-6)
+
+
+def test_slopes_are_ordinally_monotone():
+    # A positive latent-scale effect of x should push probability mass from
+    # the lowest category toward the highest one.
+    out = avg_slopes(mod, variables="x").sort("group")
+    est = out["estimate"].to_list()
+    assert est[0] < 0  # P(lowest category) decreases
+    assert est[-1] > 0  # P(highest category) increases
+
+
+def test_avg_comparisons_runs():
+    out = avg_comparisons(mod, variables="x")
+    assert out.height == ncat
+    assert out["estimate"].sum() == pytest.approx(0.0, abs=1e-6)
+    assert out["std_error"].is_finite().all()
+
+
+def test_unit_level_slopes_run():
+    out = slopes(mod, variables="x")
+    assert out.height == dat.shape[0] * ncat
+    assert out["estimate"].is_finite().all()
+
+
+def test_intercept_fit_raises_clear_error():
+    # Fitting WITH an intercept is rank-deficient (collinear with thresholds);
+    # marginaleffects must raise an explanatory error instead of returning
+    # silently corrupted estimates from the ~1e15 coefficients.
+    bad = smf.ordinal_gee("cat ~ x + z", "gid", dat, cov_struct=gor).fit()
+    with pytest.raises(ValueError, match="intercept"):
+        predictions(bad)


### PR DESCRIPTION
NominalGEE and OrdinalGEE store coefficients in an expanded multi-equation form whose inherited GLM predict cannot consume an ordinary (n, k) design, so predictions/comparisons/slopes previously failed with a cryptic numpy shape error. Reconstruct category probabilities from the plain design:

- NominalGEE: multinomial-logit inverse link over per-category linear predictors.
- OrdinalGEE: cumulative-logit survival probabilities P(Y > c_j) turned into category probabilities by successive differences. 

Both feed the existing 2-D rowid x group path used for MNLogit. Dispatch is a name->reconstructor registry (matching the family_map/link_map style in this module) rather than a class-name if/elif chain, so new models are one map entry plus one method.

This change does meaningfully enlarge `python/marginaleffects/statsmodels/model.py`.

Open to suggestions (maybe punt the predict functions into another module and out of the ModelStatsmodels class). 
Also open to rejection if too niche.