### PR TITLE
Restore the `inst/tinytest` exclusion for r-universe builds

### DIFF
--- a/r/.Rbuildignore
+++ b/r/.Rbuildignore
@@ -37,6 +37,7 @@ uv.lock
 ^vignettes/*_files$
 air.toml
 CLAUDE.md
+inst/tinytest
 pyproject.toml
 .python-version
 uv.lock


### PR DESCRIPTION
I am doing some hackery to get my fork of marginaleffects working on our r-universe (the deps are not on CRAN yet due to their break, and I need to teach with it prior to then! Will submit a PR when I get everything through.)

In the process, I discovered that your own r-universe is failing, and it appears to be due to a regression in the build ignore file. I think this will fix it. Edit: confirmed on our end that this fixes the r-universe build.