### PR TITLE
Warn when model coefficients are NA (rank deficiency)

### DIFF
--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: marginaleffects
 Title: Predictions, Comparisons, Slopes, Marginal Means, and Hypothesis Tests
-Version: 0.32.0.9994
+Version: 0.32.0.9995
 Authors@R:
     c(person(given = "Vincent",
              family = "Arel-Bundock",

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -9,6 +9,7 @@ New:
 * Support for `glmtoolbox::glmgee()` and `glmtoolbox::gnm()` models. Thanks to @luifrancgom for report #1148.
 * Support for `nestedLogit::nestedLogit()` models. Thanks to @strengejacke for report #1675.
 * Improved `type` error for `aft` models.
+* Once-per-session warning when some model coefficients are `NA`, since rank deficiency can make results depend on the order of factor levels. Thanks to @andymilne for report #1744.
 
 Breaking changes:
 

--- a/r/R/sanity_model.R
+++ b/r/R/sanity_model.R
@@ -183,6 +183,15 @@ sanitize_model <- function(model, call, newdata = NULL, vcov = NULL, by = FALSE,
     )
     sanity_model_supported_class(model)
 
+    # Aliased coefficients: predictions for combinations of predictors which do
+    # not appear in the data are arbitrary, and can flip when factor levels are
+    # reordered. Cheap O(p) check; a grid-level check would be too costly.
+    co <- hush(get_coef(model))
+    if (is.numeric(co) && anyNA(co)) {
+        msg <- "Some coefficients are `NA`, possibly because the model matrix is rank deficient. In such cases, the quantities produced by `marginaleffects` may depend on the order of factor levels."
+        warn_once(msg, "marginaleffects_rank_deficient")
+    }
+
     # Assign the sanitized model to the slot
     return(model)
 }

--- a/r/inst/tinytest/test-bugfix.R
+++ b/r/inst/tinytest/test-bugfix.R
@@ -181,3 +181,24 @@ dt[, y := 4 + x + rnorm(1000)]
 mod <- lm(data = dt, y ~ x)
 avg_slopes(mod, variables = "x")
 expect_true(data.table::is.data.table(dt))
+
+
+# Issue #1744: warn when coefficients are NA (rank deficiency)
+options(marginaleffects_safe = TRUE)
+options(marginaleffects_rank_deficient = TRUE)
+set.seed(42)
+n <- 30
+dat <- data.frame(
+    arm = rep(c("control", "A", "A", "B", "B"), each = n),
+    dose = rep(c("none", "low", "high", "low", "high"), each = n))
+dat$y <- rnorm(nrow(dat))
+dat$arm <- factor(dat$arm, levels = c("control", "A", "B"))
+dat$dose <- factor(dat$dose, levels = c("none", "low", "high"))
+mod <- lm(y ~ arm * dose, data = dat)
+expect_warning(avg_predictions(mod, vcov = FALSE), pattern = "order of factor levels")
+# once per session
+expect_silent(avg_comparisons(mod, vcov = FALSE))
+options(marginaleffects_rank_deficient = TRUE)
+expect_warning(avg_comparisons(mod, vcov = FALSE), pattern = "order of factor levels")
+options(marginaleffects_rank_deficient = TRUE)
+options(marginaleffects_safe = FALSE)


### PR DESCRIPTION
Closes #1744.

When a model matrix is rank deficient, predictions for combinations of predictors that do not appear in the data are arbitrary: they depend on which aliased columns the fitting routine dropped, and therefore can change when factor levels are merely reordered. Issue #1744 shows two identical fits whose `avg_comparisons()` estimates flip significance under a reordering of one factor's levels.

`sanitize_model()` now checks `anyNA(get_coef(model))` and raises a once-per-session warning:

> Some coefficients are `NA`, possibly because the model matrix is rank deficient. In such cases, the quantities produced by `marginaleffects` may depend on the order of factor levels.

Notes:

* The check is `O(p)` on the coefficient vector. A grid-level check (does this prediction grid contain factor combinations absent from the data?) would be more precise but too costly on large data.
* Unlike the existing insight warning about the variance-covariance matrix, this one fires regardless of the `vcov` argument.
* Silenced by `options(marginaleffects_safe = FALSE)` or `options(marginaleffects_rank_deficient = FALSE)`.

No default estimates change. The grid-restriction half of the feature request (`grid_type = "counterfactual_observed"`) is deliberately not implemented here: restricting `newdata` does not fix `avg_comparisons(variables=)`, which re-crosses the focal variable internally, and the estimand is already expressible with base R (`newdata = unique(insight::get_predictors(model))`) or a `semi_join` on the counterfactual grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)