### PR TITLE
Analytic Jacobians for slopes and nonlinear contrasts

### DIFF
--- a/python/NEWS.md
+++ b/python/NEWS.md
@@ -1,3 +1,21 @@
+# 0.6.2
+
+Performance:
+
+* Analytic Jacobians now cover GLMs on the response scale. The inverse-link
+  derivative is read from the fitted statsmodels link object, so logit, probit,
+  Poisson, and any other link exposing `inverse_deriv()` are supported without
+  an explicit list.
+* `slopes()` and `avg_slopes()` now use exact analytic Jacobians, along with the
+  `ratio`, `lnratio`, `lnor`, `lift`, and `expdydx` comparisons and their `avg`
+  and weighted variants. Elasticities (`eyex`, `eydx`, `dyex`) depend on the
+  fitted response and retain the numerical fallback.
+* Standard errors for these estimands can differ from previous versions in about
+  the 5th significant digit, because the closed form replaces a finite-difference
+  approximation. The analytic values are the accurate ones.
+* Model adapters may implement `get_link_functions()` to return
+  `(linkinv, mu_eta)` and opt into the response-scale analytic path.
+
 # 0.6.1
 
 Breaking changes:

--- a/python/marginaleffects/classes/model.py
+++ b/python/marginaleffects/classes/model.py
@@ -144,6 +144,13 @@ class ModelAbstract(ModelValidation, ABC):
     def get_autodiff_args(self):
         return None
 
+    # Adapters predicting on a response scale return `(linkinv, mu_eta)` here.
+    # `mu_eta` is the derivative of the inverse link, which turns a link-scale
+    # design matrix into a response-scale Jacobian. `None` keeps the analytic
+    # path from claiming the model.
+    def get_link_functions(self):
+        return None
+
     def get_df(self) -> float:
         return np.inf
 

--- a/python/marginaleffects/inference/analytic.py
+++ b/python/marginaleffects/inference/analytic.py
@@ -1,4 +1,4 @@
-"""Analytic Jacobians for model-matrix based linear predictions."""
+"""Analytic Jacobians for model-matrix based predictions."""
 
 from dataclasses import dataclass
 
@@ -18,15 +18,93 @@ class AnalyticResult:
     jacobian: np.ndarray
 
 
-def _linear_design(model, value, n_pred):
-    args = model.get_autodiff_args()
-    if not isinstance(args, dict) or args.get("model_type") != "linear":
-        return None
+# Comparison keys with a closed-form derivative with respect to the model
+# coefficients. Elasticities are excluded on purpose: they depend on the fitted
+# response, so their gradient needs a product rule over an extra prediction.
+_ROWWISE_OPS = {
+    "difference": lambda J_hi, J_lo, hi, lo, eps: J_hi - J_lo,
+    "dydx": lambda J_hi, J_lo, hi, lo, eps: (J_hi - J_lo) / eps,
+    "expdydx": lambda J_hi, J_lo, hi, lo, eps: (
+        (J_hi * np.exp(hi)[:, None] - J_lo * np.exp(lo)[:, None]) / (np.exp(eps) * eps)
+    ),
+    "ratio": lambda J_hi, J_lo, hi, lo, eps: (
+        (J_hi * lo[:, None] - J_lo * hi[:, None]) / np.square(lo)[:, None]
+    ),
+    # lift is hi / lo - 1, so it shares the ratio gradient.
+    "lift": lambda J_hi, J_lo, hi, lo, eps: (
+        (J_hi * lo[:, None] - J_lo * hi[:, None]) / np.square(lo)[:, None]
+    ),
+    "lnratio": lambda J_hi, J_lo, hi, lo, eps: J_hi / hi[:, None] - J_lo / lo[:, None],
+    "lnor": lambda J_hi, J_lo, hi, lo, eps: (
+        J_hi / (hi * (1 - hi))[:, None] - J_lo / (lo * (1 - lo))[:, None]
+    ),
+}
+
+# Keys whose average form is the average of the row-level comparisons, so their
+# gradient is the weighted mean of the row-level gradients.
+_LINEAR_KEYS = ("difference", "dydx", "expdydx")
+
+# Keys whose average form aggregates the predictions *before* applying a
+# nonlinear function. `H` and `L` are the aggregated high and low predictions.
+_SCALAR_OPS = {
+    "ratioavg": lambda Jb_hi, Jb_lo, H, L: (Jb_hi * L - Jb_lo * H) / L**2,
+    "liftavg": lambda Jb_hi, Jb_lo, H, L: (Jb_hi * L - Jb_lo * H) / L**2,
+    "lnratioavg": lambda Jb_hi, Jb_lo, H, L: Jb_hi / H - Jb_lo / L,
+    "lnoravg": lambda Jb_hi, Jb_lo, H, L: Jb_hi / (H * (1 - H)) - Jb_lo / (L * (1 - L)),
+}
+
+_SUPPORTED_KEYS = frozenset(
+    list(_ROWWISE_OPS)
+    + [k + suffix for k in _LINEAR_KEYS for suffix in ("avg", "avgwts")]
+    + list(_SCALAR_OPS)
+    + [k + "wts" for k in _SCALAR_OPS]
+)
+
+
+def _design(model, value, n_pred):
+    """Return the cached design matrix when it lines up with the coefficients."""
     X = np.asarray(value, dtype=float)
     coefs = np.asarray(model.get_coef()).reshape(-1)
     if X.ndim != 2 or X.shape != (n_pred, coefs.size):
         return None
     return X
+
+
+def _gradient(model, value, n_pred, link):
+    """Prediction gradient with respect to the coefficients, and its values.
+
+    On the link scale the gradient is the design matrix itself. On the response
+    scale the chain rule scales each row by the inverse-link derivative.
+    """
+    X = _design(model, value, n_pred)
+    if X is None:
+        return None
+    beta = np.asarray(model.get_coef(), dtype=float).reshape(-1)
+    eta = X @ beta
+    if link is None:
+        return X, eta
+    linkinv, mu_eta = link
+    return X * np.asarray(mu_eta(eta), dtype=float)[:, None], np.asarray(
+        linkinv(eta), dtype=float
+    )
+
+
+def _model_link(model):
+    """Return `(linkinv, mu_eta)`, `None` for link-scale models, or False."""
+    args = model.get_autodiff_args()
+    if not isinstance(args, dict):
+        return False
+    model_type = args.get("model_type")
+    if model_type == "linear":
+        return None
+    if model_type != "glm":
+        return False
+    # Adapters predating `get_link_functions()` keep the numerical fallback.
+    get_link = getattr(model, "get_link_functions", None)
+    link = get_link() if callable(get_link) else None
+    if link is None:
+        return False
+    return link
 
 
 def _align_rows(X, align):
@@ -46,22 +124,36 @@ def _apply_hypothesis(J, hyp):
     return np.asarray(hyp.H, dtype=float).T @ J
 
 
-def _weighted_rows(X, weights):
+def _group_weights(weights, n):
+    """Normalized weights matching the averaging done by the estimands."""
     if weights is None:
-        return np.mean(X, axis=0)
+        return np.full(n, 1.0 / n)
     weights = np.asarray(weights, dtype=float)
+    if weights.shape != (n,):
+        return None
     keep = ~np.isnan(weights)
     denominator = np.sum(weights[keep])
-    if denominator == 0:
-        return np.full(X.shape[1], np.nan)
-    return np.sum(X[keep] * weights[keep, None], axis=0) / denominator
-
-
-def _prediction_jacobian(plan, model):
-    X = _linear_design(model, plan.exog, plan.n_pred)
-    if X is None or plan.has_na:
+    if denominator == 0 or not np.isfinite(denominator):
         return None
-    J = _align_rows(X, plan.align)
+    out = np.where(keep, weights, 0.0) / denominator
+    if not np.all(np.isfinite(out)):
+        return None
+    return out
+
+
+def _weighted_rows(X, weights):
+    w = _group_weights(weights, X.shape[0])
+    if w is None:
+        return np.full(X.shape[1], np.nan)
+    return w @ X
+
+
+def _prediction_jacobian(plan, model, link):
+    built = _gradient(model, plan.exog, plan.n_pred, link)
+    if built is None or plan.has_na:
+        return None
+    J, values = built
+    J = _align_rows(J, plan.align)
     if J is None:
         return None
     if plan.agg is not None:
@@ -69,48 +161,72 @@ def _prediction_jacobian(plan, model):
     J = _apply_hypothesis(J, plan.hyp)
     if J is None:
         return None
-    beta = np.asarray(model.get_coef(), dtype=float).reshape(-1)
-    return J, prediction_plan_apply(plan, X @ beta)
+    return J, prediction_plan_apply(plan, values)
 
 
-def _comparison_jacobian(plan, model):
-    raw_hi = _linear_design(model, plan.exog_hi, plan.n_pred)
-    raw_lo = _linear_design(model, plan.exog_lo, plan.n_pred)
-    if raw_hi is None or raw_lo is None or plan.need_y or plan.has_na:
+def _group_jacobian(J_hi, J_lo, hi, lo, eps, group):
+    """Closed-form gradient for one comparison group, or None if ineligible."""
+    key = group.fun_key
+    if key not in _SUPPORTED_KEYS:
         return None
-    X_hi = _align_rows(raw_hi, plan.align)
-    X_lo = _align_rows(raw_lo, plan.align)
-    if X_hi is None or X_lo is None:
+    idx = np.asarray(group.idx, dtype=int)
+    n = idx.size
+    if n == 0:
+        return None
+    weighted = key.endswith("avgwts")
+    base = key[: -len("wts")] if weighted else key
+    if base.startswith(("dydx", "expdydx")) and not (
+        isinstance(eps, (int, float)) and np.isfinite(eps) and eps != 0
+    ):
         return None
 
-    beta = np.asarray(model.get_coef(), dtype=float).reshape(-1)
-    hi = X_hi @ beta
-    lo = X_lo @ beta
-    J = np.empty((plan.n_comp, beta.size), dtype=float)
+    block_hi, block_lo = J_hi[idx], J_lo[idx]
+    v_hi, v_lo = hi[idx], lo[idx]
+
+    if base in _ROWWISE_OPS:
+        return _ROWWISE_OPS[base](block_hi, block_lo, v_hi, v_lo, eps)
+
+    w = _group_weights(group.w if weighted else None, n)
+    if w is None:
+        return None
+    inner = base[: -len("avg")]
+    if inner in _LINEAR_KEYS:
+        grad = _ROWWISE_OPS[inner](block_hi, block_lo, v_hi, v_lo, eps)
+        return (w @ grad).reshape(1, -1)
+    if base in _SCALAR_OPS:
+        return _SCALAR_OPS[base](
+            w @ block_hi, w @ block_lo, float(w @ v_hi), float(w @ v_lo)
+        ).reshape(1, -1)
+    return None
+
+
+def _comparison_jacobian(plan, model, link):
+    built_hi = _gradient(model, plan.exog_hi, plan.n_pred, link)
+    built_lo = _gradient(model, plan.exog_lo, plan.n_pred, link)
+    if built_hi is None or built_lo is None or plan.need_y or plan.has_na:
+        return None
+    raw_hi, values_hi = built_hi
+    raw_lo, values_lo = built_lo
+    J_hi = _align_rows(raw_hi, plan.align)
+    J_lo = _align_rows(raw_lo, plan.align)
+    if J_hi is None or J_lo is None:
+        return None
+    hi = _align_rows(values_hi, plan.align)
+    lo = _align_rows(values_lo, plan.align)
+
+    J = np.empty((plan.n_comp, J_hi.shape[1]), dtype=float)
     for group in plan.groups:
-        idx = np.asarray(group.idx, dtype=int)
-        key = group.fun_key
-        if key == "difference":
-            value = X_hi[idx] - X_lo[idx]
-        elif key == "ratio":
-            value = (X_hi[idx] * lo[idx, None] - X_lo[idx] * hi[idx, None]) / np.square(
-                lo[idx, None]
-            )
-        elif key in {"differenceavg", "differenceavgwts"}:
-            value = _weighted_rows(X_hi[idx] - X_lo[idx], group.w)
-        elif key in {"ratioavg", "ratioavgwts"}:
-            mean_hi = _weighted_rows(X_hi[idx], group.w)
-            mean_lo = _weighted_rows(X_lo[idx], group.w)
-            pred_hi = float(mean_hi @ beta)
-            pred_lo = float(mean_lo @ beta)
-            value = (mean_hi * pred_lo - mean_lo * pred_hi) / pred_lo**2
-        else:
+        value = _group_jacobian(J_hi, J_lo, hi, lo, plan.eps, group)
+        if value is None:
             return None
-        J[group.out_idx] = np.asarray(value).reshape(-1, beta.size)
+        value = np.asarray(value, dtype=float).reshape(-1, J_hi.shape[1])
+        if value.shape[0] != np.asarray(group.out_idx).size:
+            return None
+        J[group.out_idx] = value
     J = _apply_hypothesis(J, plan.hyp)
     if J is None:
         return None
-    return J, comparison_plan_apply(plan, raw_hi @ beta, raw_lo @ beta)
+    return J, comparison_plan_apply(plan, values_hi, values_lo)
 
 
 def analytic_try(plan, model, V, estimate, kind):
@@ -122,10 +238,13 @@ def analytic_try(plan, model, V, estimate, kind):
     """
     if plan is None or V is None:
         return None
+    link = _model_link(model)
+    if link is False:
+        return None
     built = (
-        _prediction_jacobian(plan, model)
+        _prediction_jacobian(plan, model, link)
         if kind == "predictions"
-        else _comparison_jacobian(plan, model)
+        else _comparison_jacobian(plan, model, link)
     )
     if built is None:
         return None
@@ -134,6 +253,10 @@ def analytic_try(plan, model, V, estimate, kind):
     if J.shape[0] != estimate.size:
         return None
     if not plan_values_allclose(replay, estimate):
+        return None
+    # Nonlinear comparisons can divide by a zero prediction. Fall back rather
+    # than propagating a non-finite derivative into the variance.
+    if not np.all(np.isfinite(J)):
         return None
     se = get_se(J, V)
     se[se == 0] = np.nan

--- a/python/marginaleffects/statsmodels/model.py
+++ b/python/marginaleffects/statsmodels/model.py
@@ -145,6 +145,21 @@ class ModelStatsmodels(ModelAbstract):
     def get_df(self):
         return self.model.df_resid
 
+    def get_link_functions(self):
+        # Read the derivative off the statsmodels link object rather than
+        # switching on the link name, so custom and unlisted links work too.
+        inner_model = self.model.model
+        if type(inner_model).__name__ != "GLM":
+            return None
+        link = getattr(getattr(inner_model, "family", None), "link", None)
+        if link is None:
+            return None
+        linkinv = getattr(link, "inverse", None)
+        mu_eta = getattr(link, "inverse_deriv", None)
+        if not callable(linkinv) or not callable(mu_eta):
+            return None
+        return linkinv, mu_eta
+
     def get_autodiff_args(self):
         inner_model = self.model.model
         model_class = type(inner_model).__name__

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "marginaleffects"
-version = "0.6.1"
+version = "0.6.2"
 license = "GPL-3.0-or-later"
 description = "Predictions, counterfactual comparisons, slopes, and hypothesis tests for statistical models."
 readme = "README.md"

--- a/python/tests/test_autodiff.py
+++ b/python/tests/test_autodiff.py
@@ -204,10 +204,12 @@ def compare_autodiff_vs_finite_diff(func, model, rtol=1e-4, atol=1e-6, **kwargs)
 
 def test_autodiff_autodetect_unsupported_fallback_is_silent(ols_model):
     try:
+        # Elasticities depend on the fitted response, so neither the analytic
+        # nor the autodiff path can differentiate them.
         autodiff(None)
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            comparisons(ols_model, variables="x1", comparison="lift", by=False)
+            comparisons(ols_model, variables="x1", comparison="eyex", by=False)
 
         unsupported = [
             w
@@ -219,9 +221,9 @@ def test_autodiff_autodetect_unsupported_fallback_is_silent(ols_model):
         autodiff(True)
         with pytest.warns(
             UserWarning,
-            match="Automatic differentiation does not support comparison='lift'",
+            match="Automatic differentiation does not support elasticities",
         ):
-            comparisons(ols_model, variables="x1", comparison="lift", by=False)
+            comparisons(ols_model, variables="x1", comparison="eyex", by=False)
     finally:
         autodiff(None)
 

--- a/python/tests/test_inference_analytic.py
+++ b/python/tests/test_inference_analytic.py
@@ -1,3 +1,5 @@
+from dataclasses import replace
+
 import numpy as np
 
 from marginaleffects.inference.analytic import analytic_try
@@ -93,3 +95,163 @@ def test_analytic_ratio_matches_finite_difference():
     np.testing.assert_allclose(analytic.jacobian, numeric, rtol=1e-6, atol=1e-6)
 
     assert analytic_try(plan, model, np.eye(2), estimate + 1.0, "comparisons") is None
+
+
+class GlmAdapter(LinearAdapter):
+    """Logit adapter: predictions live on the response scale."""
+
+    def get_autodiff_args(self):
+        return {"model_type": "glm", "family": "binomial", "link": "logit"}
+
+    def get_link_functions(self):
+        def linkinv(eta):
+            return 1.0 / (1.0 + np.exp(-eta))
+
+        def mu_eta(eta):
+            mu = linkinv(eta)
+            return mu * (1.0 - mu)
+
+        return linkinv, mu_eta
+
+
+def _comparison_plan(X_hi, X_lo, fun_key, w=None, eps=1e-4, scalar=False):
+    n = X_hi.shape[0]
+    group = CompGroup(
+        idx=np.arange(n),
+        out_idx=np.arange(1) if scalar else np.arange(n),
+        scalar=scalar,
+        fun=estimands[fun_key],
+        fun_key=fun_key,
+        x=None,
+        w=w,
+    )
+    return ComparisonPlan(
+        n_pred=n,
+        exog_hi=X_hi,
+        exog_lo=X_lo,
+        exog_nd=None,
+        need_y=False,
+        align=None,
+        eps=eps,
+        groups=[group],
+        n_comp=1 if scalar else n,
+        hyp=None,
+    )
+
+
+def _assert_matches_finite_difference(model, plan, X_hi, X_lo, link=None):
+    def replay(beta):
+        eta_hi, eta_lo = X_hi @ beta, X_lo @ beta
+        if link is None:
+            return comparison_plan_apply(plan, eta_hi, eta_lo)
+        return comparison_plan_apply(plan, link(eta_hi), link(eta_lo))
+
+    estimate = replay(model.get_coef())
+    V = np.eye(len(model.get_coef()))
+    analytic = analytic_try(plan, model, V, estimate, "comparisons")
+    assert analytic is not None
+    numeric = get_jacobian(replay, model.get_coef())
+    # The finite-difference Jacobian is the reference here, so the tolerance
+    # reflects its accuracy rather than that of the closed form.
+    np.testing.assert_allclose(analytic.jacobian, numeric, rtol=1e-5, atol=1e-6)
+
+
+X_HI = np.asarray([[1.0, 2.0], [1.0, 4.0], [1.0, 5.0]])
+X_LO = np.asarray([[1.0, 1.0], [1.0, 3.0], [1.0, 3.5]])
+
+
+def test_analytic_rowwise_keys_match_finite_difference():
+    model = LinearAdapter([2.0, 0.5])
+    for key in ("difference", "dydx", "ratio", "lnratio", "lift", "expdydx"):
+        plan = _comparison_plan(X_HI, X_LO, key)
+        _assert_matches_finite_difference(model, plan, X_HI, X_LO)
+
+
+def test_analytic_average_keys_match_finite_difference():
+    model = LinearAdapter([2.0, 0.5])
+    # `expdydxavg` is omitted: its estimand is written against polars Series, so
+    # it cannot be replayed from the numpy arrays these plans carry.
+    keys = ("differenceavg", "dydxavg", "ratioavg", "lnratioavg", "liftavg")
+    for key in keys:
+        plan = _comparison_plan(X_HI, X_LO, key, scalar=True)
+        _assert_matches_finite_difference(model, plan, X_HI, X_LO)
+
+
+def test_analytic_weighted_average_keys_match_finite_difference():
+    model = LinearAdapter([2.0, 0.5])
+    w = np.asarray([1.0, 2.0, 3.0])
+    for key in ("differenceavgwts", "dydxavgwts", "ratioavgwts", "lnratioavgwts"):
+        plan = _comparison_plan(X_HI, X_LO, key, w=w, scalar=True)
+        _assert_matches_finite_difference(model, plan, X_HI, X_LO)
+
+
+def test_analytic_glm_response_scale_applies_the_chain_rule():
+    model = GlmAdapter([0.2, 0.3])
+    linkinv, mu_eta = model.get_link_functions()
+    for key in ("difference", "dydx", "ratio", "lnratio", "lnor"):
+        plan = _comparison_plan(X_HI, X_LO, key)
+        _assert_matches_finite_difference(model, plan, X_HI, X_LO, link=linkinv)
+
+    # The prediction Jacobian is the design matrix scaled row-wise by mu.eta().
+    beta = model.get_coef()
+    plan = PredictionPlan(
+        n_pred=3,
+        exog=X_HI,
+        align=None,
+        has_na=False,
+        agg=None,
+        hyp=None,
+        n_out=3,
+    )
+    eta = X_HI @ beta
+    out = analytic_try(plan, model, np.eye(2), linkinv(eta), "predictions")
+    np.testing.assert_allclose(out.jacobian, X_HI * mu_eta(eta)[:, None])
+
+    # Log-odds are linear in the coefficients, so `lnor` on a logit response
+    # scale must collapse back to the plain design-matrix difference. This pins
+    # the chain rule exactly, without a finite-difference reference.
+    lnor_plan = _comparison_plan(X_HI, X_LO, "lnor")
+    estimate = comparison_plan_apply(
+        lnor_plan, linkinv(X_HI @ beta), linkinv(X_LO @ beta)
+    )
+    lnor = analytic_try(lnor_plan, model, np.eye(2), estimate, "comparisons")
+    np.testing.assert_allclose(lnor.jacobian, X_HI - X_LO)
+
+
+def test_analytic_declines_unsupported_and_nonfinite_cases():
+    model = LinearAdapter([2.0, 0.5])
+    V = np.eye(2)
+
+    # Elasticities depend on the fitted response, which the plan flags.
+    plan = _comparison_plan(X_HI, X_LO, "difference")
+    estimate = comparison_plan_apply(
+        plan, X_HI @ model.get_coef(), X_LO @ model.get_coef()
+    )
+    assert analytic_try(plan, model, V, estimate, "comparisons") is not None
+    elasticity = replace(plan, need_y=True)
+    assert analytic_try(elasticity, model, V, estimate, "comparisons") is None
+
+    # A comparison function with no recorded key cannot be differentiated.
+    unkeyed = replace(plan, groups=[replace(plan.groups[0], fun_key=None)])
+    assert analytic_try(unkeyed, model, V, estimate, "comparisons") is None
+
+    # A ratio through a zero prediction has a non-finite derivative.
+    beta = np.asarray([0.0, 1.0])
+    zero_lo = np.asarray([[1.0, 0.0], [1.0, 3.0], [1.0, 3.5]])
+    plan = _comparison_plan(X_HI, zero_lo, "ratio")
+    model_zero = LinearAdapter(beta)
+    estimate = comparison_plan_apply(plan, X_HI @ beta, zero_lo @ beta)
+    assert analytic_try(plan, model_zero, V, estimate, "comparisons") is None
+
+
+def test_analytic_declines_glm_without_link_functions():
+    class NoLink(GlmAdapter):
+        def get_link_functions(self):
+            return None
+
+    model = NoLink([0.2, 0.3])
+    plan = _comparison_plan(X_HI, X_LO, "difference")
+    estimate = comparison_plan_apply(
+        plan, X_HI @ model.get_coef(), X_LO @ model.get_coef()
+    )
+    assert analytic_try(plan, model, np.eye(2), estimate, "comparisons") is None

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: marginaleffects
 Title: Predictions, Comparisons, Slopes, Marginal Means, and Hypothesis Tests
-Version: 0.32.0.9995
+Version: 0.32.0.9996
 Authors@R:
     c(person(given = "Vincent",
              family = "Arel-Bundock",

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -17,6 +17,9 @@ Breaking changes:
 
 Performance:
 
+* `slopes()` and `avg_slopes()` now use exact analytic Jacobians wherever the underlying comparison is eligible, on both the link and response scales. Previously every slope fell back to finite differences over the coefficient vector.
+* The analytic Jacobian now covers the `ratio`, `lnratio`, `lnor`, `lift`, and `expdydx` comparisons in addition to `difference`, along with their `avg` and weighted variants. Elasticities (`eyex`, `eydx`, `dyex`) depend on the fitted response and retain the numerical fallback.
+* Standard errors for these estimands can differ from previous versions in about the 5th significant digit, because the closed form replaces a finite-difference approximation. The analytic values are the accurate ones.
 * Cached model matrices now discard observation row names without copying their numeric payload. Eligible prediction plans reuse baseline linear predictors, and `avg_comparisons()` aggregates exact Jacobians directly from cached matrices instead of materializing observation-level derivatives.
 * `MASS::glm.nb()`, `MASS::rlm()`, and `brglm2::brglmFit()` models now use package-compatible model matrices and exact analytic Jacobians for eligible predictions and built-in difference comparisons. Response-scale `glm.nb` and `brglmFit` derivatives use their fitted inverse-link functions.
 * Set `options(marginaleffects_analytic_jacobian = FALSE)` to disable analytic Jacobians and force the existing autodiff or numerical fallback, which is useful for validation and debugging.

--- a/r/R/get_jacobian_analytic.R
+++ b/r/R/get_jacobian_analytic.R
@@ -1,203 +1,349 @@
-jacobian_analytic_comparison_groups <- function(J, plan) {
-  out <- matrix(NA_real_, nrow = plan$n_comp, ncol = ncol(J))
+# Comparison keys with a closed-form derivative with respect to the model
+# coefficients. Elasticities are excluded on purpose: they depend on the fitted
+# response, so their gradient needs a product rule over an extra prediction.
+jacobian_analytic_supported_keys <- c(
+    "difference",
+    "differenceavg",
+    "differenceavgwts",
+    "dydx",
+    "dydxavg",
+    "dydxavgwts",
+    "expdydx",
+    "expdydxavg",
+    "expdydxavgwts",
+    "ratio",
+    "ratioavg",
+    "ratioavgwts",
+    "lnratio",
+    "lnratioavg",
+    "lnratioavgwts",
+    "lnor",
+    "lnoravg",
+    "lnoravgwts",
+    "lift",
+    "liftavg",
+    "liftavgwts"
+)
 
-  for (g in plan$groups) {
-    block <- J[g$idx, , drop = FALSE]
-    value <- switch(g$fun_key,
-      difference = block,
-      differenceavg = matrix(colMeans(block), nrow = 1L),
-      differenceavgwts = {
-        w <- g$args$w
-        if (
-          !is.numeric(w) || length(w) != nrow(block) ||
-            any(!is.finite(w)) || sum(w) == 0
-        ) {
-          return(NULL)
-        }
-        matrix(colSums(block * w) / sum(w), nrow = 1L)
-      },
-      return(NULL)
-    )
-    if (nrow(value) != length(g$out_idx)) {
-      return(NULL)
+
+# Row-level gradients. `J_hi` and `J_lo` are the derivatives of the high and low
+# predictions with respect to the coefficients, so each entry below is just the
+# chain rule applied to the corresponding function in `comparison_function_dict`.
+# Multiplying a matrix by a vector of length `nrow()` scales its rows, which is
+# what every one of these formulas needs.
+jacobian_analytic_rowwise_ops <- list(
+    difference = function(J_hi, J_lo, hi, lo, eps) J_hi - J_lo,
+    dydx = function(J_hi, J_lo, hi, lo, eps) (J_hi - J_lo) / eps,
+    expdydx = function(J_hi, J_lo, hi, lo, eps) {
+        (J_hi * exp(hi) - J_lo * exp(lo)) / (exp(eps) * eps)
+    },
+    ratio = function(J_hi, J_lo, hi, lo, eps) (J_hi * lo - J_lo * hi) / lo^2,
+    # lift is hi / lo - 1, so it shares the ratio gradient.
+    lift = function(J_hi, J_lo, hi, lo, eps) (J_hi * lo - J_lo * hi) / lo^2,
+    lnratio = function(J_hi, J_lo, hi, lo, eps) J_hi / hi - J_lo / lo,
+    lnor = function(J_hi, J_lo, hi, lo, eps) {
+        J_hi / (hi * (1 - hi)) - J_lo / (lo * (1 - lo))
     }
-    out[g$out_idx, ] <- value
-  }
+)
 
-  out
+
+# Keys whose average form is the average of the row-level comparisons. Their
+# gradient is the weighted mean of the row-level gradients.
+jacobian_analytic_linear_keys <- c("difference", "dydx", "expdydx")
+
+
+# Keys whose average form aggregates the predictions *before* applying a
+# nonlinear function. `H` and `L` are the aggregated high and low predictions,
+# and `Jbar_hi` and `Jbar_lo` their gradients.
+jacobian_analytic_scalar_ops <- list(
+    ratioavg = function(Jbar_hi, Jbar_lo, H, L) (Jbar_hi * L - Jbar_lo * H) / L^2,
+    liftavg = function(Jbar_hi, Jbar_lo, H, L) (Jbar_hi * L - Jbar_lo * H) / L^2,
+    lnratioavg = function(Jbar_hi, Jbar_lo, H, L) Jbar_hi / H - Jbar_lo / L,
+    lnoravg = function(Jbar_hi, Jbar_lo, H, L) {
+        Jbar_hi / (H * (1 - H)) - Jbar_lo / (L * (1 - L))
+    }
+)
+
+
+# NULL signals an ineligible group, which sends the caller back to autodiff or
+# finite differences.
+jacobian_analytic_group_eps <- function(g, n) {
+    eps <- g$args$eps
+    if (!is.numeric(eps) || !length(eps) %in% c(1L, n) || any(!is.finite(eps)) || any(eps == 0)) {
+        return(NULL)
+    }
+    eps
+}
+
+
+jacobian_analytic_group_weights <- function(g, weighted, n) {
+    if (!isTRUE(weighted)) {
+        return(rep.int(1 / n, n))
+    }
+    w <- g$args$w
+    if (!is.numeric(w) || length(w) != n || any(!is.finite(w)) || sum(w) == 0) {
+        return(NULL)
+    }
+    w / sum(w)
+}
+
+
+jacobian_analytic_comparison_groups <- function(J_hi, J_lo, hi, lo, plan) {
+    out <- matrix(NA_real_, nrow = plan$n_comp, ncol = ncol(J_hi))
+
+    for (g in plan$groups) {
+        key <- g$fun_key
+        if (!isTRUE(key %in% jacobian_analytic_supported_keys)) {
+            return(NULL)
+        }
+        n <- length(g$idx)
+        if (n == 0L) {
+            return(NULL)
+        }
+        weighted <- endsWith(key, "avgwts")
+        base <- if (weighted) sub("wts$", "", key) else key
+
+        block_hi <- J_hi[g$idx, , drop = FALSE]
+        block_lo <- J_lo[g$idx, , drop = FALSE]
+        v_hi <- hi[g$idx]
+        v_lo <- lo[g$idx]
+
+        if (base %in% names(jacobian_analytic_rowwise_ops)) {
+            eps <- jacobian_analytic_group_eps(g, n)
+            if (is.null(eps) && base %in% c("dydx", "expdydx")) {
+                return(NULL)
+            }
+            value <- jacobian_analytic_rowwise_ops[[base]](
+                block_hi,
+                block_lo,
+                v_hi,
+                v_lo,
+                eps
+            )
+        } else {
+            w <- jacobian_analytic_group_weights(g, weighted, n)
+            if (is.null(w)) {
+                return(NULL)
+            }
+            inner <- sub("avg$", "", base)
+            if (inner %in% jacobian_analytic_linear_keys) {
+                eps <- jacobian_analytic_group_eps(g, n)
+                if (is.null(eps) && inner %in% c("dydx", "expdydx")) {
+                    return(NULL)
+                }
+                grad <- jacobian_analytic_rowwise_ops[[inner]](
+                    block_hi,
+                    block_lo,
+                    v_hi,
+                    v_lo,
+                    eps
+                )
+                value <- matrix(colSums(grad * w), nrow = 1L)
+            } else if (base %in% names(jacobian_analytic_scalar_ops)) {
+                value <- matrix(
+                    jacobian_analytic_scalar_ops[[base]](
+                        colSums(block_hi * w),
+                        colSums(block_lo * w),
+                        sum(v_hi * w),
+                        sum(v_lo * w)
+                    ),
+                    nrow = 1L
+                )
+            } else {
+                return(NULL)
+            }
+        }
+
+        if (nrow(value) != length(g$out_idx)) {
+            return(NULL)
+        }
+        out[g$out_idx, ] <- value
+    }
+
+    out
 }
 
 
 jacobian_analytic_aggregate <- function(J, agg) {
-  if (is.null(agg)) {
-    return(J)
-  }
-  out <- matrix(NA_real_, nrow = agg$n, ncol = ncol(J))
-
-  # Each block stores equal-size groups as columns of an index matrix. Flatten
-  # once, then rowsum() every Jacobian column simultaneously by recorded group.
-  for (block in agg$blocks) {
-    idx <- block$idx
-    if (
-      !is.matrix(idx) || nrow(idx) == 0L ||
-        any(idx < 1L | idx > nrow(J))
-    ) {
-      return(NULL)
+    if (is.null(agg)) {
+        return(J)
     }
-    group <- rep(seq_len(ncol(idx)), each = nrow(idx))
-    value <- J[as.vector(idx), , drop = FALSE]
+    out <- matrix(NA_real_, nrow = agg$n, ncol = ncol(J))
 
-    if (isTRUE(agg$weighted)) {
-      w <- block$w
-      if (
-        !is.numeric(w) || !identical(dim(w), dim(idx)) ||
-          any(!is.finite(w))
-      ) {
-        return(NULL)
-      }
-      denominator <- colSums(w)
-      if (any(denominator == 0)) {
-        return(NULL)
-      }
-      value <- rowsum(value * as.vector(w), group, reorder = FALSE)
-      value <- value / denominator
-    } else {
-      value <- rowsum(value, group, reorder = FALSE) / nrow(idx)
+    # Each block stores equal-size groups as columns of an index matrix. Flatten
+    # once, then rowsum() every Jacobian column simultaneously by recorded group.
+    for (block in agg$blocks) {
+        idx <- block$idx
+        if (!is.matrix(idx) || nrow(idx) == 0L || any(idx < 1L | idx > nrow(J))) {
+            return(NULL)
+        }
+        group <- rep(seq_len(ncol(idx)), each = nrow(idx))
+        value <- J[as.vector(idx), , drop = FALSE]
+
+        if (isTRUE(agg$weighted)) {
+            w <- block$w
+            if (!is.numeric(w) || !identical(dim(w), dim(idx)) || any(!is.finite(w))) {
+                return(NULL)
+            }
+            denominator <- colSums(w)
+            if (any(denominator == 0)) {
+                return(NULL)
+            }
+            value <- rowsum(value * as.vector(w), group, reorder = FALSE)
+            value <- value / denominator
+        } else {
+            value <- rowsum(value, group, reorder = FALSE) / nrow(idx)
+        }
+        out[block$cols, ] <- value
     }
-    out[block$cols, ] <- value
-  }
 
-  out
+    out
 }
 
 
 jacobian_analytic_hypothesis <- function(J, hyp) {
-  if (is.null(hyp)) {
-    return(J)
-  }
-  H <- hyp$H
-  if (
-    !identical(hyp$kind, "matrix") || is.null(H) ||
-      nrow(H) != nrow(J) || any(!is.finite(H))
-  ) {
-    return(NULL)
-  }
+    if (is.null(hyp)) {
+        return(J)
+    }
+    H <- hyp$H
+    if (!identical(hyp$kind, "matrix") || is.null(H) || nrow(H) != nrow(J) || any(!is.finite(H))) {
+        return(NULL)
+    }
 
-  # Linear hypotheses map estimates with crossprod(H, estimate), so the same
-  # multiplication maps every coefficient column of the Jacobian at once.
-  as.matrix(Matrix::crossprod(H, J))
+    # Linear hypotheses map estimates with crossprod(H, estimate), so the same
+    # multiplication maps every coefficient column of the Jacobian at once.
+    as.matrix(Matrix::crossprod(H, J))
 }
 
 
 jacobian_analytic_weighted_columns <- function(X, idx, w) {
-  if (identical(idx, seq_len(nrow(X)))) {
-    return(drop(crossprod(w, X)))
-  }
-  drop(crossprod(w, X[idx, , drop = FALSE]))
+    if (identical(idx, seq_len(nrow(X)))) {
+        return(drop(crossprod(w, X)))
+    }
+    drop(crossprod(w, X[idx, , drop = FALSE]))
 }
 
 
-# Average simple differences directly from cached matrices. This composes the
-# comparison-row mapping with the recorded aggregation weights, avoiding an
-# intermediate n-observation Jacobian for avg_comparisons().
+# Average simple differences and slopes directly from cached matrices. This
+# composes the comparison-row mapping with the recorded aggregation weights,
+# avoiding an intermediate n-observation Jacobian for avg_comparisons() and
+# avg_slopes(). Slopes only add a 1/eps factor to the averaging weights.
 jacobian_analytic_comparison_aggregate <- function(
-  X_hi,
-  X_lo,
-  d_hi,
-  d_lo,
-  plan
+    X_hi,
+    X_lo,
+    d_hi,
+    d_lo,
+    plan
 ) {
-  avg_keys <- c("differenceavg", "differenceavgwts")
-  group_keys <- vapply(plan$groups, `[[`, character(1), "fun_key")
+    avg_keys <- c(
+        "differenceavg",
+        "differenceavgwts",
+        "dydxavg",
+        "dydxavgwts"
+    )
+    direct_keys <- c("difference", "dydx")
+    group_keys <- vapply(plan$groups, `[[`, character(1), "fun_key")
 
-  # avg_comparisons() normally records the averaging operation directly in
-  # each comparison group. Compute those small output rows without ever
-  # allocating the corresponding observation-level derivative matrix.
-  if (length(group_keys) > 0L && all(group_keys %in% avg_keys)) {
-    out <- matrix(NA_real_, nrow = plan$n_comp, ncol = ncol(X_hi))
-    for (g in plan$groups) {
-      if (length(g$out_idx) != 1L || length(g$idx) == 0L) {
+    # avg_comparisons() and avg_slopes() normally record the averaging operation
+    # directly in each comparison group. Compute those small output rows without
+    # ever allocating the corresponding observation-level derivative matrix.
+    if (length(group_keys) > 0L && all(group_keys %in% avg_keys)) {
+        out <- matrix(NA_real_, nrow = plan$n_comp, ncol = ncol(X_hi))
+        for (g in plan$groups) {
+            if (length(g$out_idx) != 1L || length(g$idx) == 0L) {
+                return(NULL)
+            }
+            w <- jacobian_analytic_group_weights(
+                g,
+                endsWith(g$fun_key, "avgwts"),
+                length(g$idx)
+            )
+            if (is.null(w)) {
+                return(NULL)
+            }
+            if (startsWith(g$fun_key, "dydx")) {
+                eps <- jacobian_analytic_group_eps(g, length(g$idx))
+                if (is.null(eps)) {
+                    return(NULL)
+                }
+                w <- w / eps
+            }
+            w_hi <- if (is.null(d_hi)) w else w * d_hi[g$idx]
+            w_lo <- if (is.null(d_lo)) w else w * d_lo[g$idx]
+            out[g$out_idx, ] <-
+                jacobian_analytic_weighted_columns(X_hi, g$idx, w_hi) -
+                jacobian_analytic_weighted_columns(X_lo, g$idx, w_lo)
+        }
+        if (!is.null(plan$est_keep)) {
+            out <- out[plan$est_keep, , drop = FALSE]
+        }
+        return(list(J = out, aggregated = FALSE))
+    }
+
+    if (is.null(plan$agg) || length(plan$agg$blocks) == 0L) {
         return(NULL)
-      }
-      if (identical(g$fun_key, "differenceavgwts")) {
-        w <- g$args$w
-        if (
-          !is.numeric(w) || length(w) != length(g$idx) ||
-            any(!is.finite(w))
-        ) {
-          return(NULL)
+    }
+    group_ok <- vapply(
+        plan$groups,
+        function(g) {
+            isTRUE(g$fun_key %in% direct_keys) &&
+                length(g$idx) == length(g$out_idx)
+        },
+        logical(1)
+    )
+    if (!all(group_ok)) {
+        return(NULL)
+    }
+
+    raw_index <- integer(plan$n_comp)
+    # Slopes divide by an epsilon recorded per variable, so the factor has to
+    # travel with each comparison row rather than being applied once.
+    comp_scale <- rep.int(1, plan$n_comp)
+    for (g in plan$groups) {
+        raw_index[g$out_idx] <- g$idx
+        if (identical(g$fun_key, "dydx")) {
+            eps <- jacobian_analytic_group_eps(g, length(g$idx))
+            if (is.null(eps)) {
+                return(NULL)
+            }
+            comp_scale[g$out_idx] <- 1 / eps
         }
-        denominator <- sum(w)
-        if (denominator == 0) {
-          return(NULL)
-        }
-        w <- w / denominator
-      } else {
-        w <- rep.int(1 / length(g$idx), length(g$idx))
-      }
-      w_hi <- if (is.null(d_hi)) w else w * d_hi[g$idx]
-      w_lo <- if (is.null(d_lo)) w else w * d_lo[g$idx]
-      out[g$out_idx, ] <-
-        jacobian_analytic_weighted_columns(X_hi, g$idx, w_hi) -
-        jacobian_analytic_weighted_columns(X_lo, g$idx, w_lo)
     }
     if (!is.null(plan$est_keep)) {
-      out <- out[plan$est_keep, , drop = FALSE]
+        raw_index <- raw_index[plan$est_keep]
+        comp_scale <- comp_scale[plan$est_keep]
     }
-    return(list(J = out, aggregated = FALSE))
-  }
-
-  if (is.null(plan$agg) || length(plan$agg$blocks) == 0L) {
-    return(NULL)
-  }
-  group_ok <- vapply(plan$groups, function(g) {
-    identical(g$fun_key, "difference") &&
-      length(g$idx) == length(g$out_idx)
-  }, logical(1))
-  if (!all(group_ok)) {
-    return(NULL)
-  }
-
-  raw_index <- integer(plan$n_comp)
-  for (g in plan$groups) {
-    raw_index[g$out_idx] <- g$idx
-  }
-  if (!is.null(plan$est_keep)) {
-    raw_index <- raw_index[plan$est_keep]
-  }
-  if (length(raw_index) == 0L || any(raw_index == 0L)) {
-    return(NULL)
-  }
-
-  out <- matrix(NA_real_, nrow = plan$agg$n, ncol = ncol(X_hi))
-  for (block in plan$agg$blocks) {
-    idx <- block$idx
-    if (
-      !is.matrix(idx) || nrow(idx) == 0L ||
-        any(idx < 1L | idx > length(raw_index))
-    ) {
-      return(NULL)
+    if (length(raw_index) == 0L || any(raw_index == 0L)) {
+        return(NULL)
     }
-    for (j in seq_len(ncol(idx))) {
-      raw <- raw_index[idx[, j]]
-      if (isTRUE(plan$agg$weighted)) {
-        w <- block$w[, j]
-        denominator <- sum(w)
-        if (any(!is.finite(w)) || denominator == 0) {
-          return(NULL)
+
+    out <- matrix(NA_real_, nrow = plan$agg$n, ncol = ncol(X_hi))
+    for (block in plan$agg$blocks) {
+        idx <- block$idx
+        if (!is.matrix(idx) || nrow(idx) == 0L || any(idx < 1L | idx > length(raw_index))) {
+            return(NULL)
         }
-        w <- w / denominator
-      } else {
-        w <- rep.int(1 / length(raw), length(raw))
-      }
-      w_hi <- if (is.null(d_hi)) w else w * d_hi[raw]
-      w_lo <- if (is.null(d_lo)) w else w * d_lo[raw]
-      value <- jacobian_analytic_weighted_columns(X_hi, raw, w_hi) -
-        jacobian_analytic_weighted_columns(X_lo, raw, w_lo)
-      out[block$cols[j], ] <- value
+        for (j in seq_len(ncol(idx))) {
+            raw <- raw_index[idx[, j]]
+            if (isTRUE(plan$agg$weighted)) {
+                w <- block$w[, j]
+                denominator <- sum(w)
+                if (any(!is.finite(w)) || denominator == 0) {
+                    return(NULL)
+                }
+                w <- w / denominator
+            } else {
+                w <- rep.int(1 / length(raw), length(raw))
+            }
+            w <- w * comp_scale[idx[, j]]
+            w_hi <- if (is.null(d_hi)) w else w * d_hi[raw]
+            w_lo <- if (is.null(d_lo)) w else w * d_lo[raw]
+            value <- jacobian_analytic_weighted_columns(X_hi, raw, w_hi) -
+                jacobian_analytic_weighted_columns(X_lo, raw, w_lo)
+            out[block$cols[j], ] <- value
+        }
     }
-  }
-  list(J = out, aggregated = TRUE)
+    list(J = out, aggregated = TRUE)
 }
 
 
@@ -209,260 +355,278 @@ jacobian_analytic_comparison_aggregate <- function(
 #' @keywords internal
 #' @noRd
 get_jacobian_analytic <- function(model, ...) {
-  UseMethod("get_jacobian_analytic", model)
+    UseMethod("get_jacobian_analytic", model)
 }
 
 
 #' @noRd
 #' @export
 get_jacobian_analytic.default <- function(model, ...) {
-  NULL
+    NULL
 }
 
 
 jacobian_analytic_model_matrix <- function(
-  model,
-  plan,
-  kind,
-  type,
-  estimate,
-  contrast_data = NULL,
-  response_scale = FALSE,
-  family = NULL
+    model,
+    plan,
+    kind,
+    type,
+    estimate,
+    contrast_data = NULL,
+    response_scale = FALSE,
+    family = NULL
 ) {
-  # NULL means that this estimand is not safely eligible. This is an expected
-  # result which preserves the existing autodiff and finite-difference paths.
-  tryCatch(
-    {
-      if (is.null(plan) || model_has_effective_offset(model)) {
-        return(NULL)
-      }
+    # NULL means that this estimand is not safely eligible. This is an expected
+    # result which preserves the existing autodiff and finite-difference paths.
+    tryCatch(
+        {
+            if (is.null(plan) || model_has_effective_offset(model)) {
+                return(NULL)
+            }
 
-      if (isTRUE(response_scale)) {
-        if (
-          !is.list(family) || !is.function(family$linkinv) ||
-            !is.function(family$mu.eta)
-        ) {
-          return(NULL)
-        }
-      }
+            if (isTRUE(response_scale)) {
+                if (!is.list(family) || !is.function(family$linkinv) || !is.function(family$mu.eta)) {
+                    return(NULL)
+                }
+            }
 
-      # Link-scale derivatives are X rows. Eligible response-scale models add
-      # the inverse-link derivative below.
-      beta <- get_coef(model)
-      beta_names <- names(beta)
-      if (
-        !is.numeric(beta) || any(!is.finite(beta)) || is.null(beta_names) ||
-          anyDuplicated(beta_names) > 0L
-      ) {
-        return(NULL)
-      }
+            # Link-scale derivatives are X rows. Eligible response-scale models add
+            # the inverse-link derivative below.
+            beta <- get_coef(model)
+            beta_names <- names(beta)
+            if (!is.numeric(beta) || any(!is.finite(beta)) || is.null(beta_names) || anyDuplicated(beta_names) > 0L) {
+                return(NULL)
+            }
 
-      if (
-        !kind %in% c("comparisons", "predictions") ||
-          !identical(plan$kind, kind) ||
-          (!is.null(plan$hyp) && !identical(plan$hyp$kind, "matrix"))
-      ) {
-        return(NULL)
-      }
+            if (
+                !kind %in% c("comparisons", "predictions") ||
+                    !identical(plan$kind, kind) ||
+                    (!is.null(plan$hyp) && !identical(plan$hyp$kind, "matrix"))
+            ) {
+                return(NULL)
+            }
 
-      align_matrix <- function(X) {
-        if (
-          !isTRUE(checkmate::check_matrix(X, mode = "numeric")) ||
-            ncol(X) != length(beta) || any(!is.finite(X))
-        ) {
-          return(NULL)
-        }
-        xnames <- colnames(X)
-        if (
-          is.null(xnames) || anyDuplicated(xnames) > 0L ||
-            !setequal(xnames, beta_names)
-        ) {
-          return(NULL)
-        }
-        if (identical(xnames, beta_names)) {
-          X
-        } else {
-          X[, beta_names, drop = FALSE]
-        }
-      }
+            align_matrix <- function(X) {
+                if (
+                    !isTRUE(checkmate::check_matrix(X, mode = "numeric")) ||
+                        ncol(X) != length(beta) ||
+                        any(!is.finite(X))
+                ) {
+                    return(NULL)
+                }
+                xnames <- colnames(X)
+                if (is.null(xnames) || anyDuplicated(xnames) > 0L || !setequal(xnames, beta_names)) {
+                    return(NULL)
+                }
+                if (identical(xnames, beta_names)) {
+                    X
+                } else {
+                    X[, beta_names, drop = FALSE]
+                }
+            }
 
-      if (identical(kind, "comparisons")) {
-        if (
-          is.null(contrast_data) || isTRUE(plan$need_y) ||
-            length(plan$groups) == 0L
-        ) {
-          return(NULL)
-        }
-        group_ok <- vapply(plan$groups, function(g) {
-          g$fun_key %in% c("difference", "differenceavg", "differenceavgwts") &&
-            !isTRUE(g$uses_y)
-        }, logical(1))
-        if (!all(group_ok)) {
-          return(NULL)
-        }
-        X_hi <- align_matrix(attr(
-          contrast_data$hi,
-          "marginaleffects_model_matrix"
-        ))
-        X_lo <- align_matrix(attr(
-          contrast_data$lo,
-          "marginaleffects_model_matrix"
-        ))
-        if (is.null(X_hi) || is.null(X_lo) || !identical(dim(X_hi), dim(X_lo))) {
-          return(NULL)
-        }
+            if (identical(kind, "comparisons")) {
+                if (is.null(contrast_data) || isTRUE(plan$need_y) || length(plan$groups) == 0L) {
+                    return(NULL)
+                }
+                group_ok <- vapply(
+                    plan$groups,
+                    function(g) {
+                        isTRUE(g$fun_key %in% jacobian_analytic_supported_keys) &&
+                            !isTRUE(g$uses_y)
+                    },
+                    logical(1)
+                )
+                if (!all(group_ok)) {
+                    return(NULL)
+                }
+                X_hi <- align_matrix(attr(
+                    contrast_data$hi,
+                    "marginaleffects_model_matrix"
+                ))
+                X_lo <- align_matrix(attr(
+                    contrast_data$lo,
+                    "marginaleffects_model_matrix"
+                ))
+                if (is.null(X_hi) || is.null(X_lo) || !identical(dim(X_hi), dim(X_lo))) {
+                    return(NULL)
+                }
 
-        reuse <- isTRUE(plan$model_matrix_used) &&
-          identical(colnames(X_hi), beta_names) &&
-          identical(colnames(X_lo), beta_names) &&
-          is.numeric(plan$baseline_hi) &&
-          length(plan$baseline_hi) == nrow(X_hi) &&
-          is.numeric(plan$baseline_lo) &&
-          length(plan$baseline_lo) == nrow(X_lo)
-        eta_reuse <- reuse &&
-          is.numeric(plan$eta_hi) && length(plan$eta_hi) == nrow(X_hi) &&
-          is.numeric(plan$eta_lo) && length(plan$eta_lo) == nrow(X_lo)
-        if (isTRUE(response_scale) && !eta_reuse) {
-          eta_hi <- drop(X_hi %*% beta)
-          eta_lo <- drop(X_lo %*% beta)
-        } else if (eta_reuse) {
-          eta_hi <- plan$eta_hi
-          eta_lo <- plan$eta_lo
-        }
-        if (reuse) {
-          pred_hi <- plan$baseline_hi
-          pred_lo <- plan$baseline_lo
-        } else {
-          eta_hi <- drop(X_hi %*% beta)
-          eta_lo <- drop(X_lo %*% beta)
-          pred_hi <- if (isTRUE(response_scale)) family$linkinv(eta_hi) else eta_hi
-          pred_lo <- if (isTRUE(response_scale)) family$linkinv(eta_lo) else eta_lo
-        }
-        if (isTRUE(response_scale)) {
-          d_hi <- as.vector(family$mu.eta(eta_hi))
-          d_lo <- as.vector(family$mu.eta(eta_lo))
-        } else {
-          d_hi <- NULL
-          d_lo <- NULL
-        }
-        # Validate predictions on the effective scale before transforming the
-        # derivative matrix with the recorded comparison operations.
-        replay <- comparison_plan_apply(plan, pred_hi, pred_lo)
-      } else {
-        X <- align_matrix(attr(
-          plan$predict_args$newdata,
-          "marginaleffects_model_matrix"
-        ))
-        if (is.null(X)) {
-          return(NULL)
-        }
-        reuse <- isTRUE(plan$model_matrix_used) &&
-          identical(colnames(X), beta_names) &&
-          is.numeric(plan$baseline_prediction) &&
-          length(plan$baseline_prediction) == nrow(X)
-        eta_reuse <- reuse &&
-          is.numeric(plan$linear_predictor) &&
-          length(plan$linear_predictor) == nrow(X)
-        if (isTRUE(response_scale) && !eta_reuse) {
-          eta <- drop(X %*% beta)
-        } else if (eta_reuse) {
-          eta <- plan$linear_predictor
-        }
-        if (reuse) {
-          pred <- plan$baseline_prediction
-        } else {
-          eta <- drop(X %*% beta)
-          pred <- if (isTRUE(response_scale)) family$linkinv(eta) else eta
-        }
-        if (isTRUE(response_scale)) {
-          J <- X * as.vector(family$mu.eta(eta))
-        } else {
-          J <- X
-        }
-        replay <- prediction_plan_apply(plan, pred)
-      }
+                reuse <- isTRUE(plan$model_matrix_used) &&
+                    identical(colnames(X_hi), beta_names) &&
+                    identical(colnames(X_lo), beta_names) &&
+                    is.numeric(plan$baseline_hi) &&
+                    length(plan$baseline_hi) == nrow(X_hi) &&
+                    is.numeric(plan$baseline_lo) &&
+                    length(plan$baseline_lo) == nrow(X_lo)
+                eta_reuse <- reuse &&
+                    is.numeric(plan$eta_hi) &&
+                    length(plan$eta_hi) == nrow(X_hi) &&
+                    is.numeric(plan$eta_lo) &&
+                    length(plan$eta_lo) == nrow(X_lo)
+                if (isTRUE(response_scale) && !eta_reuse) {
+                    eta_hi <- drop(X_hi %*% beta)
+                    eta_lo <- drop(X_lo %*% beta)
+                } else if (eta_reuse) {
+                    eta_hi <- plan$eta_hi
+                    eta_lo <- plan$eta_lo
+                }
+                if (reuse) {
+                    pred_hi <- plan$baseline_hi
+                    pred_lo <- plan$baseline_lo
+                } else {
+                    eta_hi <- drop(X_hi %*% beta)
+                    eta_lo <- drop(X_lo %*% beta)
+                    pred_hi <- if (isTRUE(response_scale)) family$linkinv(eta_hi) else eta_hi
+                    pred_lo <- if (isTRUE(response_scale)) family$linkinv(eta_lo) else eta_lo
+                }
+                if (isTRUE(response_scale)) {
+                    d_hi <- as.vector(family$mu.eta(eta_hi))
+                    d_lo <- as.vector(family$mu.eta(eta_lo))
+                } else {
+                    d_hi <- NULL
+                    d_lo <- NULL
+                }
+                # Validate predictions on the effective scale before transforming the
+                # derivative matrix with the recorded comparison operations.
+                replay <- comparison_plan_apply(plan, pred_hi, pred_lo)
+            } else {
+                X <- align_matrix(attr(
+                    plan$predict_args$newdata,
+                    "marginaleffects_model_matrix"
+                ))
+                if (is.null(X)) {
+                    return(NULL)
+                }
+                reuse <- isTRUE(plan$model_matrix_used) &&
+                    identical(colnames(X), beta_names) &&
+                    is.numeric(plan$baseline_prediction) &&
+                    length(plan$baseline_prediction) == nrow(X)
+                eta_reuse <- reuse &&
+                    is.numeric(plan$linear_predictor) &&
+                    length(plan$linear_predictor) == nrow(X)
+                if (isTRUE(response_scale) && !eta_reuse) {
+                    eta <- drop(X %*% beta)
+                } else if (eta_reuse) {
+                    eta <- plan$linear_predictor
+                }
+                if (reuse) {
+                    pred <- plan$baseline_prediction
+                } else {
+                    eta <- drop(X %*% beta)
+                    pred <- if (isTRUE(response_scale)) family$linkinv(eta) else eta
+                }
+                if (isTRUE(response_scale)) {
+                    J <- X * as.vector(family$mu.eta(eta))
+                } else {
+                    J <- X
+                }
+                replay <- prediction_plan_apply(plan, pred)
+            }
 
-      # This is a fail-closed correctness guard, not a debugging assertion. It
-      # rejects stale matrices, offsets, prediction arguments, and future
-      # semantic changes which are not captured by the static whitelist above.
-      if (!isTRUE(all.equal(
-        replay,
-        estimate,
-        tolerance = sqrt(.Machine$double.eps),
-        check.attributes = FALSE
-      ))) {
-        return(NULL)
-      }
+            # This is a fail-closed correctness guard, not a debugging assertion. It
+            # rejects stale matrices, offsets, prediction arguments, and future
+            # semantic changes which are not captured by the static whitelist above.
+            if (
+                !isTRUE(all.equal(
+                    replay,
+                    estimate,
+                    tolerance = sqrt(.Machine$double.eps),
+                    check.attributes = FALSE
+                ))
+            ) {
+                return(NULL)
+            }
 
-      if (identical(kind, "comparisons")) {
-        if (!is.null(plan$na_keep)) {
-          X_hi <- X_hi[plan$na_keep, , drop = FALSE]
-          X_lo <- X_lo[plan$na_keep, , drop = FALSE]
-          if (!is.null(d_hi)) d_hi <- d_hi[plan$na_keep]
-          if (!is.null(d_lo)) d_lo <- d_lo[plan$na_keep]
-        }
-        if (!is.null(plan$perm)) {
-          X_hi <- X_hi[plan$perm, , drop = FALSE]
-          X_lo <- X_lo[plan$perm, , drop = FALSE]
-          if (!is.null(d_hi)) d_hi <- d_hi[plan$perm]
-          if (!is.null(d_lo)) d_lo <- d_lo[plan$perm]
-        }
+            if (identical(kind, "comparisons")) {
+                if (!is.null(plan$na_keep)) {
+                    X_hi <- X_hi[plan$na_keep, , drop = FALSE]
+                    X_lo <- X_lo[plan$na_keep, , drop = FALSE]
+                    pred_hi <- pred_hi[plan$na_keep]
+                    pred_lo <- pred_lo[plan$na_keep]
+                    if (!is.null(d_hi)) {
+                        d_hi <- d_hi[plan$na_keep]
+                    }
+                    if (!is.null(d_lo)) d_lo <- d_lo[plan$na_keep]
+                }
+                if (!is.null(plan$perm)) {
+                    X_hi <- X_hi[plan$perm, , drop = FALSE]
+                    X_lo <- X_lo[plan$perm, , drop = FALSE]
+                    pred_hi <- pred_hi[plan$perm]
+                    pred_lo <- pred_lo[plan$perm]
+                    if (!is.null(d_hi)) {
+                        d_hi <- d_hi[plan$perm]
+                    }
+                    if (!is.null(d_lo)) d_lo <- d_lo[plan$perm]
+                }
 
-        direct <- jacobian_analytic_comparison_aggregate(
-          X_hi = X_hi,
-          X_lo = X_lo,
-          d_hi = d_hi,
-          d_lo = d_lo,
-          plan = plan
-        )
-        if (is.null(direct)) {
-          aggregated_early <- FALSE
-          if (isTRUE(response_scale)) {
-            J <- X_hi * d_hi - X_lo * d_lo
-          } else {
-            J <- X_hi - X_lo
-          }
-        } else {
-          J <- direct$J
-          aggregated_early <- direct$aggregated
-        }
-        if (is.null(direct)) {
-          J <- jacobian_analytic_comparison_groups(J, plan)
-          if (is.null(J)) {
-            return(NULL)
-          }
-          if (!is.null(plan$est_keep)) {
-            J <- J[plan$est_keep, , drop = FALSE]
-          }
-        }
-      } else if (!is.null(plan$keep)) {
-        J <- J[plan$keep, , drop = FALSE]
-      }
+                direct <- jacobian_analytic_comparison_aggregate(
+                    X_hi = X_hi,
+                    X_lo = X_lo,
+                    d_hi = d_hi,
+                    d_lo = d_lo,
+                    plan = plan
+                )
+                if (is.null(direct)) {
+                    aggregated_early <- FALSE
+                    # Chain rule on each side separately: the nonlinear comparison
+                    # functions need the high and low gradients, not their difference.
+                    if (isTRUE(response_scale)) {
+                        J_hi <- X_hi * d_hi
+                        J_lo <- X_lo * d_lo
+                    } else {
+                        J_hi <- X_hi
+                        J_lo <- X_lo
+                    }
+                    J <- jacobian_analytic_comparison_groups(
+                        J_hi,
+                        J_lo,
+                        pred_hi,
+                        pred_lo,
+                        plan
+                    )
+                    if (is.null(J)) {
+                        return(NULL)
+                    }
+                    if (!is.null(plan$est_keep)) {
+                        J <- J[plan$est_keep, , drop = FALSE]
+                    }
+                } else {
+                    J <- direct$J
+                    aggregated_early <- direct$aggregated
+                }
+            } else if (!is.null(plan$keep)) {
+                J <- J[plan$keep, , drop = FALSE]
+            }
 
-      if (!identical(kind, "comparisons") || !isTRUE(aggregated_early)) {
-        J <- jacobian_analytic_aggregate(J, plan$agg)
-        if (is.null(J)) {
-          return(NULL)
-        }
-      }
-      J <- jacobian_analytic_hypothesis(J, plan$hyp)
-      if (is.null(J)) {
-        return(NULL)
-      }
+            if (!identical(kind, "comparisons") || !isTRUE(aggregated_early)) {
+                J <- jacobian_analytic_aggregate(J, plan$agg)
+                if (is.null(J)) {
+                    return(NULL)
+                }
+            }
+            J <- jacobian_analytic_hypothesis(J, plan$hyp)
+            if (is.null(J)) {
+                return(NULL)
+            }
 
-      if (nrow(J) != length(estimate)) {
-        return(NULL)
-      }
-      # Cached model matrices may carry terms metadata such as `assign` and
-      # `contrasts`. A Jacobian's contract includes only dimensions and names.
-      attributes(J) <- list(
-        dim = dim(J),
-        dimnames = list(NULL, beta_names)
-      )
+            if (nrow(J) != length(estimate)) {
+                return(NULL)
+            }
+            # Nonlinear comparisons can divide by a zero prediction. Fall back
+            # rather than propagating a non-finite derivative into the vcov.
+            if (any(!is.finite(J))) {
+                return(NULL)
+            }
+            # Cached model matrices may carry terms metadata such as `assign` and
+            # `contrasts`. A Jacobian's contract includes only dimensions and names.
+            attributes(J) <- list(
+                dim = dim(J),
+                dimnames = list(NULL, beta_names)
+            )
 
-      J
-    },
-    error = function(e) NULL
-  )
+            J
+        },
+        error = function(e) NULL
+    )
 }

--- a/r/inst/tinytest/test-by.R
+++ b/r/inst/tinytest/test-by.R
@@ -262,7 +262,9 @@ cmp1 <- comparisons(mod, variables = "cyl", comparison = fun, by = "am") |>
 cmp2 <- comparisons(mod, variables = "cyl", comparison = "ratioavg", by = "am") |>
     dplyr::arrange(am, contrast)
 expect_equivalent(cmp1$estimate, cmp2$estimate)
-expect_equivalent(cmp1$std.error, cmp2$std.error)
+# `ratioavg` uses an exact analytic Jacobian; the custom function falls back to
+# finite differences, so the standard errors only match to numerical precision.
+expect_equivalent(cmp1$std.error, cmp2$std.error, tolerance = 1e-6)
 expect_equal(nrow(cmp1), 4)
 
 

--- a/r/inst/tinytest/test-jacobian-analytic.R
+++ b/r/inst/tinytest/test-jacobian-analytic.R
@@ -475,14 +475,14 @@ tryCatch(
             comparison = "ratio",
             numderiv = "fdforward"
         )
-        expect_equal(.GlobalEnv$analytic_fd_calls, 1L)
+        expect_equal(.GlobalEnv$analytic_fd_calls, 0L)
 
         avg_comparisons(
             mod_lm,
             variables = list(hp = c(100, 110)),
             numderiv = "fdforward"
         )
-        expect_equal(.GlobalEnv$analytic_fd_calls, 1L)
+        expect_equal(.GlobalEnv$analytic_fd_calls, 0L)
 
         comparisons(
             mod_lm,
@@ -491,7 +491,7 @@ tryCatch(
             hypothesis = c(1, -1),
             numderiv = "fdforward"
         )
-        expect_equal(.GlobalEnv$analytic_fd_calls, 1L)
+        expect_equal(.GlobalEnv$analytic_fd_calls, 0L)
 
         comparisons(
             mod_lm,
@@ -500,7 +500,7 @@ tryCatch(
             comparison = function(hi, lo) hi - lo,
             numderiv = "fdforward"
         )
-        expect_equal(.GlobalEnv$analytic_fd_calls, 2L)
+        expect_equal(.GlobalEnv$analytic_fd_calls, 1L)
 
         mod_offset <- lm(mpg ~ hp + offset(wt), data = mtcars)
         comparisons(
@@ -509,7 +509,7 @@ tryCatch(
             newdata = "mean",
             numderiv = "fdforward"
         )
-        expect_equal(.GlobalEnv$analytic_fd_calls, 3L)
+        expect_equal(.GlobalEnv$analytic_fd_calls, 2L)
 
         mod_rank_deficient <- lm(mpg ~ hp + I(hp), data = mtcars)
         suppressWarnings(comparisons(
@@ -518,7 +518,7 @@ tryCatch(
             newdata = "mean",
             numderiv = "fdforward"
         ))
-        expect_equal(.GlobalEnv$analytic_fd_calls, 4L)
+        expect_equal(.GlobalEnv$analytic_fd_calls, 3L)
 
         mod_subclass <- mod_lm
         class(mod_subclass) <- c("analytic_audit_lm", class(mod_subclass))
@@ -528,7 +528,7 @@ tryCatch(
             newdata = "mean",
             numderiv = "fdforward"
         )
-        expect_equal(.GlobalEnv$analytic_fd_calls, 5L)
+        expect_equal(.GlobalEnv$analytic_fd_calls, 4L)
 
         comparisons(
             mod_glm,
@@ -537,7 +537,7 @@ tryCatch(
             type = "response",
             numderiv = "fdforward"
         )
-        expect_equal(.GlobalEnv$analytic_fd_calls, 5L)
+        expect_equal(.GlobalEnv$analytic_fd_calls, 4L)
 
         # The global opt-out must actually invoke the fallback, not merely
         # produce a numerically identical result through the analytic route.
@@ -551,7 +551,7 @@ tryCatch(
             ),
             finally = options(old_option)
         )
-        expect_equal(.GlobalEnv$analytic_fd_calls, 6L)
+        expect_equal(.GlobalEnv$analytic_fd_calls, 5L)
 
         mod_glm_offset <- glm(
             am ~ hp + offset(log(wt)),
@@ -565,7 +565,7 @@ tryCatch(
             type = "response",
             numderiv = "fdforward"
         )
-        expect_equal(.GlobalEnv$analytic_fd_calls, 7L)
+        expect_equal(.GlobalEnv$analytic_fd_calls, 6L)
 
         mod_glm_rank_deficient <- glm(
             am ~ hp + I(hp),
@@ -579,7 +579,7 @@ tryCatch(
             type = "response",
             numderiv = "fdforward"
         ))
-        expect_equal(.GlobalEnv$analytic_fd_calls, 8L)
+        expect_equal(.GlobalEnv$analytic_fd_calls, 7L)
     },
     finally = {
         suppressMessages(invisible(utils::capture.output(
@@ -590,4 +590,114 @@ tryCatch(
         )))
         rm("analytic_fd_calls", envir = .GlobalEnv)
     }
+)
+
+
+# Slopes and nonlinear contrasts have closed-form Jacobians. Each estimand is
+# checked against the finite-difference fallback, which is the reference these
+# derivatives replace. The tolerance reflects the accuracy of that reference,
+# not of the analytic path.
+mod_key_lm <- lm(mpg ~ hp + wt + factor(am), data = mtcars)
+mod_key_glm <- glm(vs ~ hp + wt, family = binomial, data = mtcars)
+mod_key_pois <- glm(carb ~ hp + wt, family = poisson, data = mtcars)
+
+expect_analytic_matches_fd <- function(call, tolerance = 1e-3) {
+    call <- substitute(call)
+    analytic <- eval(call, parent.frame())
+    old <- options(marginaleffects_analytic_jacobian = FALSE)
+    numeric <- tryCatch(eval(call, parent.frame()), finally = options(old))
+    expect_equivalent(analytic$std.error, numeric$std.error, tolerance = tolerance)
+    expect_true(all(is.finite(analytic$std.error)))
+    invisible(NULL)
+}
+
+expect_analytic_matches_fd(slopes(mod_key_lm))
+expect_analytic_matches_fd(avg_slopes(mod_key_lm))
+expect_analytic_matches_fd(avg_slopes(mod_key_lm, by = "am"))
+expect_analytic_matches_fd(comparisons(mod_key_lm, comparison = "ratio"))
+expect_analytic_matches_fd(comparisons(mod_key_lm, comparison = "lnratio"))
+expect_analytic_matches_fd(comparisons(mod_key_lm, comparison = "lift"))
+expect_analytic_matches_fd(avg_comparisons(mod_key_lm, comparison = "ratio"))
+expect_analytic_matches_fd(avg_comparisons(mod_key_lm, comparison = "lnratio"))
+expect_analytic_matches_fd(avg_comparisons(mod_key_lm, comparison = "lift"))
+
+expect_analytic_matches_fd(slopes(mod_key_glm, type = "response"))
+expect_analytic_matches_fd(avg_slopes(mod_key_glm, type = "response"))
+expect_analytic_matches_fd(avg_slopes(mod_key_glm, type = "link"))
+expect_analytic_matches_fd(
+    comparisons(mod_key_glm, comparison = "lnor", type = "response")
+)
+expect_analytic_matches_fd(
+    avg_comparisons(mod_key_glm, comparison = "lnor", type = "response")
+)
+expect_analytic_matches_fd(
+    avg_comparisons(mod_key_glm, comparison = "ratio", type = "response")
+)
+
+# Unit-level Poisson slopes are the case where finite differences are least
+# accurate, so they are pinned to the exact derivative below instead.
+expect_analytic_matches_fd(slopes(mod_key_pois, type = "response"), tolerance = 1e-2)
+expect_analytic_matches_fd(avg_slopes(mod_key_pois, type = "response"))
+
+X_pois <- model.matrix(mod_key_pois)
+beta_pois <- coef(mod_key_pois)
+mu_pois <- exp(drop(X_pois %*% beta_pois))
+J_pois <- mu_pois * X_pois * beta_pois[["hp"]]
+J_pois[, "hp"] <- J_pois[, "hp"] + mu_pois
+expect_equivalent(
+    slopes(mod_key_pois, type = "response", variables = "hp")$std.error,
+    sqrt(rowSums(tcrossprod(J_pois, vcov(mod_key_pois)) * J_pois)),
+    tolerance = 1e-6
+)
+
+# The average marginal effect of a logit has a closed form that does not go
+# through the package, so it pins down the analytic path independently.
+X_ame <- model.matrix(mod_key_glm)
+beta_ame <- coef(mod_key_glm)
+mu_ame <- mod_key_glm$family$linkinv(drop(X_ame %*% beta_ame))
+d1_ame <- mu_ame * (1 - mu_ame)
+d2_ame <- d1_ame * (1 - 2 * mu_ame)
+J_ame <- t(sapply(2:3, function(k) {
+    colMeans(d2_ame * X_ame) * beta_ame[[k]] +
+        (seq_along(beta_ame) == k) * mean(d1_ame)
+}))
+expect_equivalent(
+    avg_slopes(mod_key_glm, type = "response")$std.error,
+    sqrt(rowSums(tcrossprod(J_ame, vcov(mod_key_glm)) * J_ame)),
+    tolerance = 1e-6
+)
+
+# Weighted averages divide by the recorded weights, not by the row count.
+dat_wts <- transform(mtcars, wcol = seq(1, 2, length.out = nrow(mtcars)))
+mod_wts <- lm(mpg ~ hp + wt, data = dat_wts)
+expect_analytic_matches_fd(avg_slopes(mod_wts, wts = "wcol", newdata = dat_wts))
+expect_analytic_matches_fd(
+    avg_comparisons(mod_wts, comparison = "ratio", wts = "wcol", newdata = dat_wts)
+)
+
+# A `by` data frame records aggregation in blocks rather than in the comparison
+# groups, so slopes reach the averaging fast path through a different branch.
+dat_byframe <- transform(mtcars, cyl = as.factor(cyl))
+mod_byframe <- lm(mpg ~ hp + wt + cyl, data = dat_byframe)
+by_frame <- data.frame(
+    cyl = factor(c(4, 6, 8)),
+    by = c("small", "small", "big")
+)
+expect_analytic_matches_fd(
+    comparisons(mod_byframe, variables = "cyl", by = by_frame)
+)
+expect_analytic_matches_fd(
+    slopes(mod_byframe, variables = "hp", by = by_frame)
+)
+
+# Elasticities depend on the fitted response, so they keep using the fallback.
+expect_equal(
+    marginaleffects:::get_jacobian_analytic(
+        mod_key_lm,
+        plan = NULL,
+        kind = "comparisons",
+        type = "response",
+        estimate = numeric(0)
+    ),
+    NULL
 )


### PR DESCRIPTION
## Summary

The exact-derivative path covered only `difference` comparisons. That left `slopes()` and `avg_slopes()` — the package's namesake — falling back to finite differences over the coefficient vector on **every** model, along with every ratio-family contrast.

This extends the closed-form Jacobian in both R and Python to `dydx`, `ratio`, `lnratio`, `lnor`, `lift`, and `expdydx`, plus their `avg` and weighted variants.

Coverage before/after on a handful of representative calls (`analytic=TRUE` means the closed form was used):

| call | before | after |
|---|---|---|
| `slopes(lm)` / `avg_slopes(lm)` | ✗ | ✓ |
| `slopes(glm, type="response")` | ✗ | ✓ |
| `avg_slopes(glm, by=...)` | ✗ | ✓ |
| `comparisons(..., comparison="ratio"/"lnratio"/"lift")` | ✗ | ✓ |
| `avg_comparisons(glm, comparison="lnor")` | ✗ | ✓ |
| `avg_slopes(slope="eyex")` | ✗ | ✗ (by design) |

## Approach

Row-level gradients are the chain rule applied to the corresponding entries in `comparison_function_dict` (R) / `estimands` (Python). The `avg` forms split into two families:

- keys whose average is the average of row-level comparisons (`difference`, `dydx`, `expdydx`) → weighted mean of the row-level gradients;
- keys that aggregate the predictions *before* applying a nonlinear function (`ratioavg`, `lnratioavg`, `lnoravg`, `liftavg`) → gradient evaluated at the aggregated predictions.

`lift` shares the `ratio` gradient, since `lift = hi/lo - 1`.

**The x-derivative stays numerical.** Only the coefficient-side gradient is closed-form, so the two-point `(hi, lo)` structure is untouched and formula terms like `I()`, `poly()`, and splines need no special handling — the analytic path only ever sees an already-built design matrix. Elasticities (`eyex`, `eydx`, `dyex`) keep the fallback because they depend on the fitted response and need a product rule.

## Python: response-scale GLMs

Python gains the chain rule R already had. The inverse-link derivative is read off the fitted statsmodels link object via `inverse_deriv()` rather than switching on a link-name string, so custom and unlisted links work without an enumeration. Adapters opt in with a new `get_link_functions()` returning `(linkinv, mu_eta)`.

## Accuracy

The replay guard is unchanged: a closed-form Jacobian is returned only if replaying the plan reproduces the point estimates. Both packages now additionally reject a non-finite Jacobian and fall back rather than propagating it into the variance.

Standard errors for the newly covered estimands can move in about the 5th significant digit. **The analytic values are the accurate ones** — the tests pin them to closed forms computed outside the package:

- logit AME: analytic matches the exact form to `2e-10`; finite differences were off by `2e-5`
- unit-level Poisson slopes: analytic to `4e-9`; finite differences off by `3.3e-3`

A pleasant check that fell out: `lnor` on a logit response scale must collapse exactly to `X_hi - X_lo`, since log-odds are linear in the coefficients. That is asserted directly, with no numerical reference.

## Test changes (please review)

Two existing tests encoded the narrower whitelist and had to change:

- `test-jacobian-analytic.R` — the cumulative finite-difference call counters shift by one, because the `comparison = "ratio"` call no longer reaches the fallback. Every subsequent expected count is decremented; the rest of the test (offsets, rank deficiency, custom functions, the global opt-out) is unchanged in meaning.
- `test-by.R` — compares a custom `comparison` function (still finite differences) against `"ratioavg"` (now exact). They agree to `5.3e-8`, just above tinytest's default `sqrt(.Machine$double.eps)`, so that one assertion gets an explicit tolerance.
- `test_autodiff.py` — the "forcing autodiff warns when unsupported" test used `comparison="lift"`, which the analytic path now handles before autodiff is reached. Switched to `eyex`, which is genuinely outside both paths.

## Testing

- R: full suite `All ok, 2559 results`
- Python: `350 passed` (6 pre-existing plot image-regression failures deselected; they fail identically on `main`)
- `ruff` error count unchanged from the 238 pre-existing baseline

New tests: 45 R assertions in `test-jacobian-analytic.R` and 6 Python tests in `test_inference_analytic.py`, covering every new key, weighted averages, both aggregation branches, GLM response scale, and the fallback cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)