### PR TITLE
Fall back to the model matrix when predict() fails (#1748)

### DIFF
--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: marginaleffects
 Title: Predictions, Comparisons, Slopes, Marginal Means, and Hypothesis Tests
-Version: 0.32.0.9995
+Version: 0.32.0.9996
 Authors@R:
     c(person(given = "Vincent",
              family = "Arel-Bundock",

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -35,6 +35,7 @@ Performance:
 
 Bug fixes:
 
+* `lm` and `glm` estimates no longer fail when the fit object was stripped of its `qr$qr` element to save memory. Linear predictions are now computed from the model matrix when `stats::predict()` fails. Thanks to @trose64 for report #1748.
 * `by` aggregation with posterior or bootstrap draws no longer flattens the draws matrix when a `by` data frame omits some term/group combinations.
 * `predictions()` now assigns the correct `rowid`, `type`, and `estimate` column names when model predictions are returned as a bare vector.
 * `equivalence` tests now support vector-valued degrees of freedom.

--- a/r/R/comparisons_plan.R
+++ b/r/R/comparisons_plan.R
@@ -153,7 +153,7 @@ comparison_plan_build <- function(
     newdata <- mfx@newdata
     model <- if (is.null(model_perturbed)) mfx@model else model_perturbed
 
-    predictions <- predictions_hi_lo(model, lo, hi, type, ...)
+    predictions <- predictions_hi_lo(model, lo, hi, type, mfx = mfx, ...)
     pred_lo <- predictions$pred_lo
     pred_hi <- predictions$pred_hi
     eta_lo <- attr(pred_lo, "marginaleffects_linear_predictor")
@@ -181,6 +181,7 @@ comparison_plan_build <- function(
             model,
             type = type,
             newdata = original,
+            mfx = mfx,
             ...
         )
     } else {

--- a/r/R/get_model_matrix.R
+++ b/r/R/get_model_matrix.R
@@ -97,3 +97,30 @@ add_model_matrix_attribute <- function(mfx, newdata = NULL) {
     attr(newdata, "marginaleffects_model_matrix") <- MM
     return(newdata)
 }
+
+
+#' Attach a model matrix after `stats::predict()` failed
+#'
+#' `get_predict()` methods that can compute a linear predictor from
+#' `X %*% beta` call this to build the model matrix on demand, rather than
+#' giving up on the error raised by `stats::predict()`. When no usable matrix
+#' can be built, the original error is re-raised so unrelated failures keep
+#' their own message.
+#'
+#' @param mfx marginaleffects object, or `NULL` when the caller has none
+#' @param newdata data frame to add attributes to
+#' @param beta coefficient vector the matrix columns must match
+#' @param error condition raised by `stats::predict()`
+#' @keywords internal
+#' @noRd
+model_matrix_retry <- function(mfx, newdata, beta, error) {
+    if (is.null(mfx)) {
+        stop(error)
+    }
+    newdata <- add_model_matrix_attribute(mfx, newdata)
+    MM <- attr(newdata, "marginaleffects_model_matrix")
+    if (!isTRUE(checkmate::check_matrix(MM)) || ncol(MM) != length(beta)) {
+        stop(error)
+    }
+    return(newdata)
+}

--- a/r/R/methods_aaa.R
+++ b/r/R/methods_aaa.R
@@ -27,17 +27,30 @@ get_predict.lm <- function(
     model,
     newdata = get_modeldata(model),
     type = "response",
+    mfx = NULL,
     ...) {
     MM <- attr(newdata, "marginaleffects_model_matrix")
     beta <- get_coef(model)
     if (!isTRUE(checkmate::check_matrix(MM)) || ncol(MM) != length(beta)) {
-        out <- get_predict.default(
-            model = model,
-            newdata = newdata,
-            type = type,
-            ...
+        out <- tryCatch(
+            get_predict.default(
+                model = model,
+                newdata = newdata,
+                type = type,
+                mfx = mfx,
+                ...
+            ),
+            error = function(e) e
         )
-        return(out)
+        if (!inherits(out, "error")) {
+            return(out)
+        }
+        # `stats::predict()` failed. Linear predictions only need the model
+        # matrix and the coefficients, so retry that way. This rescues fit
+        # objects stripped of components that `predict()` requires, such as
+        # `qr$qr` deleted to save memory.
+        newdata <- model_matrix_retry(mfx, newdata, beta, out)
+        MM <- attr(newdata, "marginaleffects_model_matrix")
     }
     p <- model$rank
     p1 <- seq_len(p)
@@ -53,6 +66,7 @@ get_predict.lm <- function(
         model = model,
         newdata = newdata,
         type = type,
+        mfx = mfx,
         pred = pred,
         ...
     )
@@ -70,25 +84,47 @@ get_predict.glm <- function(
     model,
     newdata = get_modeldata(model),
     type = "response",
+    mfx = NULL,
     ...) {
     out <- NULL
+    link <- isTRUE(checkmate::check_choice(type, "link"))
+    response <- isTRUE(checkmate::check_choice(type, "response")) || is.null(type)
     MM <- attr(newdata, "marginaleffects_model_matrix")
-    if (isTRUE(checkmate::check_matrix(MM))) {
-        if (isTRUE(checkmate::check_choice(type, c("link")))) {
-            out <- get_predict.lm(model = model, newdata = newdata, ...)
-        } else if (isTRUE(checkmate::check_choice(type, "response")) || is.null(type)) {
-            out <- get_predict.lm(model = model, newdata = newdata, ...)
+    if (isTRUE(checkmate::check_matrix(MM)) && (link || response)) {
+        out <- get_predict.lm(model = model, newdata = newdata, mfx = mfx, ...)
+        if (response) {
             out$estimate <- stats::family(model)$linkinv(out$estimate)
         }
     }
 
     if (is.null(out)) {
-        out <- get_predict.default(
-            model = model,
-            newdata = newdata,
-            type = type,
-            ...
+        out <- tryCatch(
+            get_predict.default(
+                model = model,
+                newdata = newdata,
+                type = type,
+                mfx = mfx,
+                ...
+            ),
+            error = function(e) e
         )
+        if (inherits(out, "error")) {
+            # See the comment in `get_predict.lm()`: retry through the model
+            # matrix, which only makes sense on the link and response scales.
+            if (!link && !response) {
+                stop(out)
+            }
+            newdata <- model_matrix_retry(
+                mfx,
+                newdata,
+                get_coef(model),
+                out
+            )
+            out <- get_predict.lm(model = model, newdata = newdata, mfx = mfx, ...)
+            if (response) {
+                out$estimate <- stats::family(model)$linkinv(out$estimate)
+            }
+        }
     }
 
     return(out)

--- a/r/inst/tinytest/test-bugfix.R
+++ b/r/inst/tinytest/test-bugfix.R
@@ -202,3 +202,38 @@ options(marginaleffects_rank_deficient = TRUE)
 expect_warning(avg_comparisons(mod, vcov = FALSE), pattern = "order of factor levels")
 options(marginaleffects_rank_deficient = TRUE)
 options(marginaleffects_safe = FALSE)
+
+
+# Issue #1748: `stats::predict()` fails when `qr$qr` is deleted from the fit to
+# save memory. Linear predictions do not need a QR decomposition, so the model
+# matrix path produces the same estimates.
+options(marginaleffects_rank_deficient = TRUE)
+dat <- mtcars
+dat$hp2 <- dat$hp + 2
+mod <- lm(mpg ~ hp + hp2, data = dat)
+stripped <- mod
+stripped$qr$qr <- NULL
+for (FUN in list(avg_predictions, avg_comparisons, avg_slopes)) {
+    known <- suppressWarnings(FUN(mod, vcov = FALSE))
+    unknown <- suppressWarnings(FUN(stripped, vcov = FALSE))
+    expect_equivalent(known$estimate, unknown$estimate)
+}
+
+mod <- glm(am ~ hp + hp2, data = dat, family = binomial())
+stripped <- mod
+stripped$qr$qr <- NULL
+for (ty in c("response", "link")) {
+    known <- suppressWarnings(avg_predictions(mod, type = ty, vcov = FALSE))
+    unknown <- suppressWarnings(avg_predictions(stripped, type = ty, vcov = FALSE))
+    expect_equivalent(known$estimate, unknown$estimate)
+}
+known <- suppressWarnings(avg_comparisons(mod, vcov = FALSE))
+unknown <- suppressWarnings(avg_comparisons(stripped, vcov = FALSE))
+expect_equivalent(known$estimate, unknown$estimate)
+
+# unrelated `predict()` failures still report their own cause
+expect_error(
+    predictions(mod, newdata = data.frame(zzz = 1)),
+    pattern = "Unable to compute predicted values"
+)
+options(marginaleffects_rank_deficient = TRUE)


### PR DESCRIPTION
Closes #1748.

## Problem

Deleting `qr$qr` from an `lm`/`glm` fit to save memory breaks `stats::predict()` itself:

```r
fit <- lm(mpg ~ hp + hp2, data = df)
fit$qr$qr <- NULL
predict(fit, newdata = df)
#> Error: 'from' must be a finite number   (via min(dim(R)) -> Inf)
```

marginaleffects used to sidestep this: `get_predict.lm()` computes `X %*% beta` from the cached model matrix and never touches the QR decomposition. #1741 made that cache conditional on delta-method inference (`r/R/predictions.R:260`, `r/R/get_comparisons_data.R:175`), so `vcov = FALSE` calls now fall through to the failing `predict()` method and surface as:

> Unable to compute predicted values with this model. […] 'from' must be a finite number

This affects `predictions()`, `comparisons()`, and `slopes()`. Rank deficiency is incidental — any stripped fit fails the same way.

## Fix

Rather than restoring the unconditional cache and giving up #1741's performance win, make the matrix path a real fallback instead of an incidental one. When `stats::predict()` raises an error, `get_predict.lm()` / `get_predict.glm()` build the model matrix on demand and retry through `X %*% beta`.

- The matrix is still not built on the `vcov = FALSE` happy path — construction only happens after `predict()` has already failed, which never happens for a well-formed fit.
- If no usable matrix can be built, the **original** `predict()` error is re-raised, so unrelated failures (stale modeldata, factor-level mismatches) keep their own message.
- `add_model_matrix_attribute()`'s existing guards still apply, so the retry can't silently produce wrong numbers for models where `X %*% beta` isn't the right computation — it returns no attribute and we re-raise.
- The glm retry is restricted to the link and response scales.

`comparison_plan_build()` reached `get_predict.lm()` with `mfx = NULL`, so `mfx` is now threaded through `predictions_hi_lo()` and the `pred_or` call; `predictions()` already passed it.

## Tests

New cases in `test-bugfix.R` cover `lm` and `glm` (response and link) across predictions/comparisons/slopes with `qr$qr` stripped, asserting the estimates match the un-stripped fit exactly, plus one asserting unrelated `predict()` failures still report their own cause.

`make r-testseq`: All ok, 2521 results.