### PR TITLE
r/R changes from jacobian-stage-composition (review scope only)

### DIFF
--- a/r/R/by.R
+++ b/r/R/by.R
@@ -10,19 +10,13 @@ harmonize_by_types <- function(estimates, by) {
 }
 
 
-get_by <- function(
-    estimates,
-    draws,
-    newdata,
-    by,
-    verbose = TRUE,
-    ...) {
-    if (is.null(by) || isFALSE(by) || nrow(estimates) <= 1) {
-        out <- estimates
-        attr(out, "posterior_draws") <- draws
-        return(out)
-    }
-
+# Resolve the `by` argument against a table of estimates: merge grouping
+# columns which live only in `newdata`, join a `by` data frame of labels,
+# warn about and drop rows a partial `by` data frame does not cover, and
+# return the grouping column names. Shared by the display aggregation
+# (get_by) and the replay recording (record_plan_aggregation) so the two can
+# never disagree about what a group is.
+resolve_by_rows <- function(estimates, newdata, by, verbose = TRUE, draws = NULL) {
     missing <- setdiff(setdiff(colnames(by), "by"), colnames(estimates))
     if (length(missing) > 0) {
         estimates <- merge_original_data(
@@ -47,6 +41,7 @@ get_by <- function(
     }
 
     if ("by" %in% colnames(estimates) && anyNA(estimates[["by"]])) {
+        # User-supplied by data can intentionally cover only some rows.
         msg <- insight::format_message(
             "The `by` data.frame does not cover all combinations of response levels and/or predictors. Some estimates will not be included in the aggregation."
         )
@@ -59,6 +54,33 @@ get_by <- function(
     }
 
     bycols <- intersect(unique(c("term", bycols)), colnames(estimates))
+    list(estimates = estimates, draws = draws, bycols = bycols)
+}
+
+
+get_by <- function(
+    estimates,
+    draws,
+    newdata,
+    by,
+    verbose = TRUE,
+    ...) {
+    if (is.null(by) || isFALSE(by) || nrow(estimates) <= 1) {
+        out <- estimates
+        attr(out, "posterior_draws") <- draws
+        return(out)
+    }
+
+    resolved <- resolve_by_rows(
+        estimates,
+        newdata,
+        by,
+        verbose = verbose,
+        draws = draws
+    )
+    estimates <- resolved$estimates
+    draws <- resolved$draws
+    bycols <- resolved$bycols
 
     # bayesian
     if (!is.null(draws)) {

--- a/r/R/class.R
+++ b/r/R/class.R
@@ -28,6 +28,9 @@ setClassUnion("logicalOrNULL", c("logical", "NULL"))
 #' @slot df The degrees of freedom
 #' @slot eps Epsilon value for numerical derivatives
 #' @slot jacobian The jacobian matrix or NULL
+#' @slot jacobian_method String naming the differentiation path which produced
+#'   the jacobian: "analytic", "analytic+numeric_stage", "numeric", "custom",
+#'   or NULL
 #' @slot model The fitted model object
 #' @slot modeldata The model data frame
 #' @slot newdata The new data frame for predictions
@@ -54,6 +57,7 @@ setClass(
         hypothesis_direction = "ANY",
         inferences = "ANY",
         jacobian = "matrixOrNULL",
+        jacobian_method = "characterOrNULL",
         model = "ANY",
         modeldata = "ANY", # TODO: lmerTest returns nfnGroupedData
         modeldata_available = "logical",
@@ -99,6 +103,7 @@ new_marginaleffects_internal <- function(
     hypothesis_null = NULL,
     hypothesis_direction = NULL,
     jacobian = NULL,
+    jacobian_method = NULL,
     modeldata = NULL,
     numderiv = list("fdforward"),
     type = NULL,
@@ -152,6 +157,7 @@ new_marginaleffects_internal <- function(
         hypothesis_null = hypothesis_null,
         hypothesis_direction = hypothesis_direction,
         jacobian = jacobian,
+        jacobian_method = jacobian_method,
         model = model,
         modeldata = modeldata,
         modeldata_available = TRUE,

--- a/r/R/comparisons.R
+++ b/r/R/comparisons.R
@@ -231,6 +231,8 @@ comparisons <- function(
     numderiv = "fdforward",
     ...
 ) {
+    vcov <- sanitize_vcov_request(vcov)
+
     # init
     mfx <- marginaleffects_init(
         model = model,
@@ -271,6 +273,10 @@ comparisons <- function(
     inferences_dispatch <- sanitize_inferences_method(vcov)
     vcov <- inferences_dispatch$vcov
     inferences_method <- inferences_dispatch$method
+    unconditional <- inherits(vcov, "marginaleffects_vcov_unconditional")
+    if (unconditional) {
+        vcov <- sanitize_unconditional_vcov_request(vcov, mfx)
+    }
 
     # misc
     mfx@conf_level <- sanitize_conf_level(conf_level, ...)
@@ -301,10 +307,17 @@ comparisons <- function(
     # get dof before transforming the vcov arg
     # add_degrees_of_freedom() produces a weird warning on non lmerMod. We can skip them
     # because get_vcov() will produce an informative error later.
-    mfx <- add_degrees_of_freedom(mfx = mfx, df = df, by = by, hypothesis = hypothesis, vcov = vcov)
+    mfx <- add_degrees_of_freedom(
+        mfx = mfx,
+        df = df,
+        by = by,
+        hypothesis = hypothesis,
+        vcov = vcov)
 
-    mfx@vcov_type <- get_vcov_label(vcov)
-    mfx@vcov_model <- get_vcov(mfx@model, vcov = vcov, type = mfx@type, ...)
+    if (!unconditional) {
+        mfx@vcov_type <- get_vcov_label(vcov)
+        mfx@vcov_model <- get_vcov(mfx@model, vcov = vcov, type = mfx@type, ...)
+    }
 
     predictors <- mfx@variables
 
@@ -345,12 +358,12 @@ comparisons <- function(
     # bayesian posterior
     mfx@draws <- attr(cmp, "posterior_draws")
 
-    # standard errors via delta method
     se <- plan_std_error(
         built = built,
         mfx = mfx,
         estimates = cmp,
         type = mfx@type,
+        vcov = vcov,
         dots = dots,
         contrast_data = contrast_data,
         variables = predictors,
@@ -359,7 +372,7 @@ comparisons <- function(
     mfx <- se$mfx
     cmp <- se$estimates
 
-    # Common path for both autodiff and fallback
+    # Common path for both the analytic and fallback paths
 
     cmp <- merge_original_data(
         cmp,
@@ -415,6 +428,9 @@ avg_comparisons <- function(
     ...
 ) {
     call_attr <- construct_call(model, "comparisons")
+    if (missing(df)) {
+        call_attr[["df"]] <- NULL
+    }
 
     out <- eval.parent(call_attr)
 

--- a/r/R/comparisons_plan.R
+++ b/r/R/comparisons_plan.R
@@ -7,6 +7,21 @@ predictions_hi_lo <- function(model, lo, hi, type, ...) {
 }
 
 
+comparison_subset_newdata <- function(newdata, idx) {
+    if (!is.data.frame(newdata) && !is.matrix(newdata)) {
+        return(newdata)
+    }
+    if (
+        anyNA(idx) ||
+            any(idx < 1L) ||
+            any(idx > nrow(newdata))
+    ) {
+        stop_sprintf("Internal error: comparison rows could not be aligned with `newdata`.")
+    }
+    newdata[idx, , drop = FALSE]
+}
+
+
 comparison_call_args <- function(term, wts, tmp_idx, context) {
     tn <- term[1]
     key <- if (isTRUE(context$cross)) 1L else tn
@@ -15,9 +30,15 @@ comparison_call_args <- function(term, wts, tmp_idx, context) {
 
     args <- list(
         "eps" = context$variables[[tn]]$eps,
-        "w" = wts,
-        "newdata" = context$newdata
+        "w" = wts
     )
+
+    # A comparison is evaluated one term/group at a time. Pass only the
+    # matching rows to functions which request `newdata`; otherwise grouped
+    # comparisons receive a full data frame alongside shorter hi/lo vectors.
+    if ("newdata" %in% fun_formals) {
+        args[["newdata"]] <- comparison_subset_newdata(context$newdata, tmp_idx)
+    }
 
     # sometimes x is exactly the same length, but not always
     args[["x"]] <- context$elasticities[[tn]][tmp_idx]
@@ -162,9 +183,14 @@ comparison_plan_build <- function(
     matrix_used_hi <- isTRUE(attr(pred_hi, "marginaleffects_model_matrix_used"))
     out <- data.table(pred_lo)
 
+    # The `*avgwts` variants are what sanitize_variables() rewrites the `*avg`
+    # shorthands into when `wts` is supplied. Omitting them here left `need_y`
+    # false, so `y` and the elasticity column were never prepared and the
+    # weighted comparison functions returned NA.
     elasticity_names <- c(
         "eyex", "eydx", "dyex",
-        "eyexavg", "eydxavg", "dyexavg"
+        "eyexavg", "eydxavg", "dyexavg",
+        "eyexavgwts", "eydxavgwts", "dyexavgwts"
     )
     fun <- function(x) {
         isTRUE(checkmate::check_choice(x$comparison, choices = elasticity_names))
@@ -308,7 +334,23 @@ comparison_plan_build <- function(
         tmp <- intersect(colnames(newdata), c(by, colnames(out)))
         if (length(tmp) > 1) {
             tmp <- subset(newdata, select = tmp)
-            out <- tryCatch(merge(out, tmp, all.x = TRUE, sort = FALSE), error = function(e) {warning(e); out})
+            # A failed merge is only tolerable when the grouping columns are
+            # already present: without them, downstream aggregation would
+            # silently drop the user's `by` groups.
+            out <- tryCatch(
+                merge(out, tmp, all.x = TRUE, sort = FALSE),
+                error = function(e) {
+                    if (all(by %in% colnames(out))) {
+                        warning(e)
+                        out
+                    } else {
+                        stop_sprintf(
+                            "Internal error: the `by` columns could not be merged into the comparison estimates: %s",
+                            conditionMessage(e)
+                        )
+                    }
+                }
+            )
             idx <- unique(c(idx, by))
         }
     }

--- a/r/R/comparisons_plan_bayesian.R
+++ b/r/R/comparisons_plan_bayesian.R
@@ -264,7 +264,21 @@ compare_hi_lo_bayesian_scalar <- function(
 
     first_idx <- vapply(group_indices, `[[`, integer(1), 1L)
     settings_set("marginaleffects_safefun_return1", TRUE)
+    # As on the frequentist path: the comparison consumed the unit-level
+    # weights, so the surviving row's weight in any further aggregation is
+    # the group's total weight, not the stale weight of its first source row.
+    total_wts <- NULL
+    if ("marginaleffects_wts_internal" %in% colnames(out)) {
+        total_wts <- vapply(
+            group_indices,
+            function(idx) sum(as.numeric(out$marginaleffects_wts_internal[idx])),
+            numeric(1)
+        )
+    }
     out <- subset(out[first_idx, , drop = FALSE], select = comparison_scalar_columns(out, by))
+    if (!is.null(total_wts)) {
+        out[, "marginaleffects_wts_internal" := total_wts]
+    }
     out[, "estimate" := comparison_posterior_center(draws_scalar)]
 
     return(list(out = out, draws = draws_scalar))

--- a/r/R/comparisons_plan_frequentist.R
+++ b/r/R/comparisons_plan_frequentist.R
@@ -32,7 +32,12 @@ comparison_plan_build_frequentist <- function(
     lo,
     original,
     need_y) {
-    na_keep <- if (anyNA(out$predicted_lo)) which(!is.na(out$predicted_lo)) else NULL
+    # Both operands decide missingness symmetrically: a finite lo with a
+    # missing hi is just as uncomputable as the reverse, and letting it
+    # through surfaced later as a misleading complaint about the user's
+    # comparison function.
+    keep_mask <- !is.na(out$predicted_lo) & !is.na(out$predicted_hi)
+    na_keep <- if (all(keep_mask)) NULL else which(keep_mask)
     if (!is.null(na_keep)) {
         out <- out[na_keep]
     }
@@ -58,6 +63,7 @@ comparison_plan_build_frequentist <- function(
     plan_groups <- vector("list", nrow(bounds))
     out_rows <- vector("list", nrow(bounds))
     estimates <- vector("list", nrow(bounds))
+    out_wts <- vector("list", nrow(bounds))
     n_comp <- 0L
     any_scalar_aggregate <- FALSE
 
@@ -65,13 +71,14 @@ comparison_plan_build_frequentist <- function(
         rows <- seq.int(bounds$first[[j]], bounds$last[[j]])
         n <- length(rows)
         term <- out_sorted$term[rows]
+        group_wts <- out_sorted$marginaleffects_wts_internal[rows]
         call <- comparison_call(
             hi = out_sorted$predicted_hi[rows],
             lo = out_sorted$predicted_lo[rows],
             y = out_sorted$predicted[rows],
             n = n,
             term = term,
-            wts = out_sorted$marginaleffects_wts_internal[rows],
+            wts = group_wts,
             tmp_idx = out_sorted$tmp_idx[rows],
             context = context
         )
@@ -84,11 +91,19 @@ comparison_plan_build_frequentist <- function(
             out_idx <- n_comp + 1L
             out_rows[[j]] <- rows[[1]]
             estimates[[j]] <- con
+            # The comparison consumed the unit-level weights and its output
+            # row stands for the whole group. Any further aggregation must
+            # weight that row by the group's total weight -- the pooled
+            # weighted mean -- never by the stale weight of whichever source
+            # row happened to come first, which is 0/0 = NaN when that weight
+            # is zero. Zero weights are routine in ATT/matching workflows.
+            out_wts[[j]] <- sum(group_wts)
             n_comp <- n_comp + 1L
         } else {
             out_idx <- seq.int(n_comp + 1L, n_comp + n)
             out_rows[[j]] <- rows
             estimates[[j]] <- con
+            out_wts[[j]] <- group_wts
             n_comp <- n_comp + n
         }
         plan_groups[[j]] <- list(
@@ -104,6 +119,11 @@ comparison_plan_build_frequentist <- function(
 
     if (isTRUE(any_scalar_aggregate)) {
         out <- out_sorted[unlist(out_rows, use.names = FALSE)]
+        if ("marginaleffects_wts_internal" %in% colnames(out)) {
+            out[,
+                marginaleffects_wts_internal := unlist(out_wts, use.names = FALSE)
+            ]
+        }
     } else {
         out <- out_sorted
     }
@@ -157,6 +177,11 @@ comparison_plan_build_frequentist <- function(
 
 
 comparison_plan_apply <- function(plan, hi, lo, y = NULL) {
+    comparison_plan_apply_stages(plan, hi, lo, y = y)$post
+}
+
+
+comparison_plan_apply_stages <- function(plan, hi, lo, y = NULL) {
     stopifnot(length(hi) == plan$n_pred)
     stopifnot(length(lo) == plan$n_pred)
     if (!is.null(plan$na_keep)) {
@@ -187,7 +212,7 @@ comparison_plan_apply <- function(plan, hi, lo, y = NULL) {
     if (!is.null(plan$est_keep)) {
         est <- est[plan$est_keep]
     }
-    apply_plan_aggregation_and_hypothesis(est, plan$agg, plan$hyp)
+    apply_plan_stages(est, plan$agg, plan$hyp)
 }
 
 

--- a/r/R/get_ci.R
+++ b/r/R/get_ci.R
@@ -258,8 +258,21 @@ get_ci_draws <- function(x, conf_level, draws, model = NULL) {
     Bs <- apply(draws, 1, FUN_CENTER)
     # comparison returns a single value
     if (nrow(x) < nrow(CIs)) {
-        CIs <- unique(CIs)
-        Bs <- unique(Bs)
+        # Deduplicate the interval and the center jointly: deduplicating them
+        # separately can drop different rows whenever two distinct estimands
+        # coincide in one summary but not the other, silently misaligning
+        # centers with intervals. If the joint deduplication does not land
+        # exactly on the number of estimates, alignment is unknowable.
+        keep <- !duplicated(cbind(Bs, CIs))
+        CIs <- CIs[keep, , drop = FALSE]
+        Bs <- Bs[keep]
+        if (nrow(CIs) != nrow(x)) {
+            stop_sprintf(
+                "Internal error: cannot align posterior draw summaries (%s unique rows) with the %s estimates.",
+                nrow(CIs),
+                nrow(x)
+            )
+        }
     }
     x[["estimate"]] <- Bs
     x[["conf.low"]] <- CIs[, "lower"]

--- a/r/R/get_hypotheses.R
+++ b/r/R/get_hypotheses.R
@@ -1,4 +1,8 @@
-get_hypotheses <- function(model_perturbed, hypothesis, hypothesis_is_formula, newparams = NULL, ...) {
+# The estimates on which the hypothesis is evaluated, before the hypothesis is
+# applied. Callers which need to differentiate the hypothesis exactly must
+# compile it against these estimates, so the extraction is factored out here
+# rather than duplicated.
+get_hypotheses_skeleton <- function(model_perturbed, hypothesis, hypothesis_is_formula, newparams = NULL, ...) {
     if (isTRUE(checkmate::check_numeric(model_perturbed))) {
         out <- data.frame(term = seq_along(model_perturbed), estimate = model_perturbed)
     } else if (inherits(model_perturbed, "data.frame")) {
@@ -42,6 +46,18 @@ get_hypotheses <- function(model_perturbed, hypothesis, hypothesis_is_formula, n
         out <- model_perturbed
     }
 
+    return(out)
+}
+
+
+get_hypotheses <- function(model_perturbed, hypothesis, hypothesis_is_formula, newparams = NULL, ...) {
+    out <- get_hypotheses_skeleton(
+        model_perturbed = model_perturbed,
+        hypothesis = hypothesis,
+        hypothesis_is_formula = hypothesis_is_formula,
+        newparams = newparams,
+        ...
+    )
 
     tmp <- get_hypothesis(out, hypothesis = hypothesis)
 

--- a/r/R/get_jacobian.R
+++ b/r/R/get_jacobian.R
@@ -23,10 +23,12 @@ get_jacobian <- function(func, x, numderiv) {
 }
 
 
-get_jacobian_fdforward <- function(func, x, eps = NULL) {
-    # old version. probably not optimal. Keep for posterity.
-    # h <- max(1e-8, 1e-4 * min(abs(x), na.rm = TRUE))
-    baseline <- func(x)
+# Forward and central finite differences share everything but the pair of
+# evaluation points: forward evaluates a shared baseline plus one shifted
+# point per coefficient, central evaluates two half-shifted points and no
+# baseline.
+get_jacobian_fd <- function(func, x, eps = NULL, center = FALSE) {
+    baseline <- if (isTRUE(center)) NULL else func(x)
 
     # we pre-chunk because future does not cache datasets in nodes, which means we
     # must pass every worker the full data and model for every future.
@@ -39,9 +41,16 @@ get_jacobian_fdforward <- function(func, x, eps = NULL) {
             } else {
                 h <- eps
             }
-            dx <- x
-            dx[i] <- dx[i] + h
-            out[[j]] <- (func(dx) - baseline) / h
+            if (isTRUE(center)) {
+                dx_hi <- dx_lo <- x
+                dx_hi[i] <- dx_hi[i] + h / 2
+                dx_lo[i] <- dx_lo[i] - h / 2
+                out[[j]] <- (func(dx_hi) - func(dx_lo)) / h
+            } else {
+                dx <- x
+                dx[i] <- dx[i] + h
+                out[[j]] <- (func(dx) - baseline) / h
+            }
         }
         out <- do.call(cbind, out)
         return(out)
@@ -66,42 +75,13 @@ get_jacobian_fdforward <- function(func, x, eps = NULL) {
 }
 
 
-get_jacobian_fdcenter <- function(func, x, eps = NULL) {
-    # we pre-chunk because future does not cache datasets in nodes, which means we
-    # must pass every worker the full data and model for every future.
-    inner_loop <- function(chunk, ...) {
-        out <- vector("list", length(chunk))
-        for (j in seq_along(chunk)) {
-            i <- chunk[[j]]
-            if (is.null(eps)) {
-                h <- max(abs(x[i]) * sqrt(.Machine$double.eps), 1e-10)
-            } else {
-                h <- eps
-            }
-            dx_hi <- dx_lo <- x
-            dx_hi[i] <- dx_hi[i] + h / 2
-            dx_lo[i] <- dx_lo[i] - h / 2
-            out[[j]] <- (func(dx_hi) - func(dx_lo)) / h
-        }
-        out <- do.call(cbind, out)
-        return(out)
-    }
+get_jacobian_fdforward <- function(func, x, eps = NULL) {
+    get_jacobian_fd(func, x, eps = eps, center = FALSE)
+}
 
-    if (isTRUE(getOption("marginaleffects_parallel", default = FALSE))) {
-        insight::check_if_installed("future.apply")
-        insight::check_if_installed("future")
-        insight::check_if_installed("parallel")
-        chunks <- parallel::splitIndices(length(x), future::nbrOfWorkers())
-        df <- future.apply::future_lapply(
-            chunks,
-            inner_loop,
-            future.seed = TRUE
-        )
-        df <- do.call("cbind", df)
-    } else {
-        df <- inner_loop(seq_along(x))
-    }
-    return(df)
+
+get_jacobian_fdcenter <- function(func, x, eps = NULL) {
+    get_jacobian_fd(func, x, eps = eps, center = TRUE)
 }
 
 

--- a/r/R/get_jacobian_analytic.R
+++ b/r/R/get_jacobian_analytic.R
@@ -1,25 +1,135 @@
-jacobian_analytic_comparison_groups <- function(J, plan) {
-  out <- matrix(NA_real_, nrow = plan$n_comp, ncol = ncol(J))
+# Finiteness of a whole matrix, in one reduction rather than one comparison per
+# element. Any NA, NaN, or Inf makes the total non-finite, and no combination of
+# them cancels back to a finite value: +Inf and -Inf together give NaN. The one
+# false verdict this can return is on a matrix whose finite entries overflow
+# when summed, which rejects a matrix the elementwise scan would have accepted
+# and so fails in the safe direction. Integers are left to the ordinary scan,
+# because summing them overflows to NA with a warning.
+matrix_all_finite <- function(x) {
+  if (!is.double(x)) {
+    return(all(is.finite(x)))
+  }
+  is.finite(sum(x))
+}
+
+
+# Predictions and inverse-link derivative for one cached model matrix.
+#
+# Reuses the plan's cached predictions and linear predictor when they are
+# trustworthy -- the pipeline's predictions actually came through this matrix
+# and the cached vectors have the right shape -- and recomputes from X and
+# beta otherwise. The linear predictor is computed at most once, whether it
+# is wanted for the inverse-link derivative, for the predictions, or both.
+# `family` may be NULL on the link scale, where `d` is NULL as well.
+jacobian_analytic_scale <- function(
+  X,
+  beta,
+  cached_pred,
+  cached_eta,
+  model_matrix_used,
+  response_scale,
+  family
+) {
+  reuse <- isTRUE(model_matrix_used) &&
+    identical(colnames(X), names(beta)) &&
+    is.numeric(cached_pred) && length(cached_pred) == nrow(X)
+  eta_reuse <- reuse &&
+    is.numeric(cached_eta) && length(cached_eta) == nrow(X)
+  eta <- NULL
+  if (eta_reuse) {
+    eta <- cached_eta
+  } else if (isTRUE(response_scale) || !reuse) {
+    eta <- drop(X %*% beta)
+  }
+  pred <- if (reuse) {
+    cached_pred
+  } else if (isTRUE(response_scale)) {
+    family$linkinv(eta)
+  } else {
+    eta
+  }
+  d <- if (isTRUE(response_scale)) as.vector(family$mu.eta(eta)) else NULL
+  list(pred = pred, d = d)
+}
+
+
+# The exact derivatives of the built-in comparison functions live next to the
+# forward definitions they mirror, in `comparison_gradient_exact()` in
+# R/sanitize_comparison.R, so that neither can be edited without the other in
+# view.
+
+
+# Comparison groups whose function is not one of the recorded differences.
+#
+# `X_hi` and `X_lo` are the model matrices of the hi and lo rows, and `d_hi`
+# and `d_lo` the inverse-link derivatives at those rows, or NULL on the link
+# scale. Their product is the exact derivative of the predictions with respect
+# to the coefficients. The comparison stage applies a recorded built-in whose
+# derivative is known in closed form, so the stage gradients compose exactly:
+# d(comparison)/d(beta) = dc/d(hi) * d(hi)/d(beta) + dc/d(lo) * d(lo)/d(beta).
+#
+# The inverse-link derivative is folded into the stage gradient before either
+# touches a model matrix, because that product is a vector and the matrix is
+# not. A group which contracts its rows to a single value then never needs the
+# observation-level derivative at all: its row is a pair of weighted column
+# sums, which `crossprod()` forms without allocating an n x p matrix that the
+# contraction would immediately discard.
+#
+# Returns NULL whenever any group's function is not a recorded built-in or its
+# gradient is not finite, which keeps the whole estimand on its previous path
+# rather than mixing methods.
+jacobian_analytic_comparison_exact <- function(
+  X_hi,
+  X_lo,
+  d_hi,
+  d_lo,
+  pred_hi,
+  pred_lo,
+  plan
+) {
+  out <- matrix(NA_real_, nrow = plan$n_comp, ncol = ncol(X_hi))
 
   for (g in plan$groups) {
-    block <- J[g$idx, , drop = FALSE]
-    value <- switch(g$fun_key,
-      difference = block,
-      differenceavg = matrix(colMeans(block), nrow = 1L),
-      differenceavgwts = {
-        w <- g$args$w
-        if (
-          !is.numeric(w) || length(w) != nrow(block) ||
-            any(!is.finite(w)) || sum(w) == 0
-        ) {
-          return(NULL)
-        }
-        matrix(colSums(block * w) / sum(w), nrow = 1L)
-      },
+    key <- g$fun_key
+    # A custom closure records fun_key = NA. It must land on the numeric
+    # fallback: arbitrary code has no recorded closed form, and probing it
+    # cannot prove one.
+    if (
+      isTRUE(g$uses_y) || !is.character(key) || length(key) != 1L || is.na(key)
+    ) {
       return(NULL)
+    }
+    idx <- g$idx
+    n_out <- length(g$out_idx)
+    grad <- comparison_gradient_exact(
+      fun_key = key,
+      hi = pred_hi[idx],
+      lo = pred_lo[idx],
+      args = g$args
     )
-    if (nrow(value) != length(g$out_idx)) {
+    if (
+      is.null(grad) ||
+        !stage_probe_finite(grad$hi) || !stage_probe_finite(grad$lo) ||
+        length(grad$hi) != length(idx) || length(grad$lo) != length(idx)
+    ) {
       return(NULL)
+    }
+
+    w_hi <- if (is.null(d_hi)) grad$hi else grad$hi * d_hi[idx]
+    w_lo <- if (is.null(d_lo)) grad$lo else grad$lo * d_lo[idx]
+
+    if (isTRUE(g$scalar)) {
+      if (n_out != 1L) {
+        return(NULL)
+      }
+      value <- jacobian_analytic_weighted_columns(X_hi, idx, w_hi) +
+        jacobian_analytic_weighted_columns(X_lo, idx, w_lo)
+    } else {
+      if (n_out != length(idx)) {
+        return(NULL)
+      }
+      value <- X_hi[idx, , drop = FALSE] * w_hi +
+        X_lo[idx, , drop = FALSE] * w_lo
     }
     out[g$out_idx, ] <- value
   }
@@ -28,24 +138,42 @@ jacobian_analytic_comparison_groups <- function(J, plan) {
 }
 
 
-jacobian_analytic_aggregate <- function(J, agg) {
-  if (is.null(agg)) {
-    return(J)
+# The weights of a recorded aggregation, as the entries of a sparse matrix.
+#
+# An aggregation is a linear map, out = t(W) %*% M. Written densely W is
+# n x agg$n and the product costs n * agg$n * p. But the plan records exactly
+# one (source row, output row) pair per source row, so W has only n entries and
+# the same product costs a single pass over M. Collecting the entries from
+# every block at once also avoids aggregating group by group, which would
+# subset M once per group and so copy the whole matrix across the loop --
+# several times the cost of the arithmetic it feeds.
+#
+# Returns NULL when the recorded aggregation is not of the expected shape.
+jacobian_analytic_aggregate_weights <- function(agg, n_rows) {
+  if (is.null(agg) || length(agg$blocks) == 0L) {
+    return(NULL)
   }
-  out <- matrix(NA_real_, nrow = agg$n, ncol = ncol(J))
+  n_entries <- sum(vapply(agg$blocks, function(b) length(b$idx), integer(1)))
+  if (!is.finite(n_entries) || n_entries == 0L) {
+    return(NULL)
+  }
 
-  # Each block stores equal-size groups as columns of an index matrix. Flatten
-  # once, then rowsum() every Jacobian column simultaneously by recorded group.
+  rows <- integer(n_entries)
+  cols <- integer(n_entries)
+  vals <- numeric(n_entries)
+  at <- 0L
+
   for (block in agg$blocks) {
     idx <- block$idx
     if (
       !is.matrix(idx) || nrow(idx) == 0L ||
-        any(idx < 1L | idx > nrow(J))
+        any(idx < 1L | idx > n_rows)
     ) {
       return(NULL)
     }
-    group <- rep(seq_len(ncol(idx)), each = nrow(idx))
-    value <- J[as.vector(idx), , drop = FALSE]
+    if (length(block$cols) != ncol(idx)) {
+      return(NULL)
+    }
 
     if (isTRUE(agg$weighted)) {
       w <- block$w
@@ -56,36 +184,102 @@ jacobian_analytic_aggregate <- function(J, agg) {
         return(NULL)
       }
       denominator <- colSums(w)
-      if (any(denominator == 0)) {
+      if (any(!is.finite(denominator)) || any(denominator == 0)) {
         return(NULL)
       }
-      value <- rowsum(value * as.vector(w), group, reorder = FALSE)
-      value <- value / denominator
+      # `idx` is column-major, so each group's entries are contiguous and the
+      # per-group denominators line up by repetition.
+      wts <- as.vector(w) / rep(denominator, each = nrow(idx))
     } else {
-      value <- rowsum(value, group, reorder = FALSE) / nrow(idx)
+      wts <- rep.int(1 / nrow(idx), length(idx))
     }
-    out[block$cols, ] <- value
+
+    span <- at + seq_len(length(idx))
+    rows[span] <- as.vector(idx)
+    cols[span] <- rep(block$cols, each = nrow(idx))
+    vals[span] <- wts
+    at <- at + length(idx)
   }
 
-  out
+  list(rows = rows, cols = cols, vals = vals)
 }
 
 
-jacobian_analytic_hypothesis <- function(J, hyp) {
+# Contract a matrix by a recorded aggregation. A single output row -- an
+# unstratified average, the common case -- is one weighted column sum, which
+# crossprod() forms without building any matrix at all.
+jacobian_analytic_aggregate_contract <- function(M, agg, rows, cols, vals) {
+  if (identical(as.integer(agg$n), 1L)) {
+    return(matrix(jacobian_analytic_weighted_columns(M, rows, vals), nrow = 1L))
+  }
+  W <- Matrix::sparseMatrix(
+    i = rows,
+    j = cols,
+    x = vals,
+    dims = c(nrow(M), agg$n)
+  )
+  as.matrix(Matrix::crossprod(W, M))
+}
+
+
+# Aggregated prediction Jacobians, straight from the model matrix.
+#
+# The observation-level Jacobian of a prediction is X scaled row-wise by the
+# inverse-link derivative, and an aggregating estimand immediately contracts
+# those rows away. Forming the n x p product first is wasted work in both
+# directions: it allocates a matrix the size of X only to reduce it to a
+# handful of rows. Folding the row scaling into the aggregation weights -- a
+# vector -- lets the contraction read straight off X instead.
+#
+# `d` is the inverse-link derivative, or NULL on the link scale.
+jacobian_analytic_aggregate_direct <- function(X, d, agg) {
+  weights <- jacobian_analytic_aggregate_weights(agg, nrow(X))
+  if (is.null(weights)) {
+    return(NULL)
+  }
+  vals <- if (is.null(d)) {
+    weights$vals
+  } else {
+    weights$vals * d[weights$rows]
+  }
+  if (!all(is.finite(vals))) {
+    return(NULL)
+  }
+  jacobian_analytic_aggregate_contract(
+    X, agg, weights$rows, weights$cols, vals
+  )
+}
+
+
+jacobian_analytic_aggregate <- function(J, agg) {
+  if (is.null(agg)) {
+    return(J)
+  }
+  weights <- jacobian_analytic_aggregate_weights(agg, nrow(J))
+  if (is.null(weights)) {
+    return(NULL)
+  }
+  jacobian_analytic_aggregate_contract(
+    J, agg, weights$rows, weights$cols, weights$vals
+  )
+}
+
+
+jacobian_analytic_hypothesis <- function(J, hyp, estimate_pre = NULL) {
   if (is.null(hyp)) {
     return(J)
   }
-  H <- hyp$H
-  if (
-    !identical(hyp$kind, "matrix") || is.null(H) ||
-      nrow(H) != nrow(J) || any(!is.finite(H))
-  ) {
+
+  res <- hypothesis_stage_pullback(hyp, J, at = estimate_pre)
+  if (is.null(res)) {
     return(NULL)
   }
-
-  # Linear hypotheses map estimates with crossprod(H, estimate), so the same
-  # multiplication maps every coefficient column of the Jacobian at once.
-  as.matrix(Matrix::crossprod(H, J))
+  out <- res$jacobian
+  # Only a probed stage costs the result its analytic provenance.
+  if (!isTRUE(res$exact)) {
+    attr(out, "marginaleffects_numeric_stage") <- TRUE
+  }
+  out
 }
 
 
@@ -97,9 +291,12 @@ jacobian_analytic_weighted_columns <- function(X, idx, w) {
 }
 
 
-# Average simple differences directly from cached matrices. This composes the
-# comparison-row mapping with the recorded aggregation weights, avoiding an
-# intermediate n-observation Jacobian for avg_comparisons().
+# Rowwise simple differences with a recorded aggregation, composed directly
+# from cached matrices: the comparison-row mapping folds into the aggregation
+# weights, so the intermediate n-observation Jacobian of avg_comparisons() is
+# never allocated. Scalar-aggregating difference keys do not come here; their
+# per-group gradients in jacobian_analytic_comparison_exact() contract with
+# crossprod() and skip the observation-level matrix just the same.
 jacobian_analytic_comparison_aggregate <- function(
   X_hi,
   X_lo,
@@ -107,46 +304,6 @@ jacobian_analytic_comparison_aggregate <- function(
   d_lo,
   plan
 ) {
-  avg_keys <- c("differenceavg", "differenceavgwts")
-  group_keys <- vapply(plan$groups, `[[`, character(1), "fun_key")
-
-  # avg_comparisons() normally records the averaging operation directly in
-  # each comparison group. Compute those small output rows without ever
-  # allocating the corresponding observation-level derivative matrix.
-  if (length(group_keys) > 0L && all(group_keys %in% avg_keys)) {
-    out <- matrix(NA_real_, nrow = plan$n_comp, ncol = ncol(X_hi))
-    for (g in plan$groups) {
-      if (length(g$out_idx) != 1L || length(g$idx) == 0L) {
-        return(NULL)
-      }
-      if (identical(g$fun_key, "differenceavgwts")) {
-        w <- g$args$w
-        if (
-          !is.numeric(w) || length(w) != length(g$idx) ||
-            any(!is.finite(w))
-        ) {
-          return(NULL)
-        }
-        denominator <- sum(w)
-        if (denominator == 0) {
-          return(NULL)
-        }
-        w <- w / denominator
-      } else {
-        w <- rep.int(1 / length(g$idx), length(g$idx))
-      }
-      w_hi <- if (is.null(d_hi)) w else w * d_hi[g$idx]
-      w_lo <- if (is.null(d_lo)) w else w * d_lo[g$idx]
-      out[g$out_idx, ] <-
-        jacobian_analytic_weighted_columns(X_hi, g$idx, w_hi) -
-        jacobian_analytic_weighted_columns(X_lo, g$idx, w_lo)
-    }
-    if (!is.null(plan$est_keep)) {
-      out <- out[plan$est_keep, , drop = FALSE]
-    }
-    return(list(J = out, aggregated = FALSE))
-  }
-
   if (is.null(plan$agg) || length(plan$agg$blocks) == 0L) {
     return(NULL)
   }
@@ -169,69 +326,148 @@ jacobian_analytic_comparison_aggregate <- function(
     return(NULL)
   }
 
-  out <- matrix(NA_real_, nrow = plan$agg$n, ncol = ncol(X_hi))
-  for (block in plan$agg$blocks) {
-    idx <- block$idx
-    if (
-      !is.matrix(idx) || nrow(idx) == 0L ||
-        any(idx < 1L | idx > length(raw_index))
-    ) {
-      return(NULL)
-    }
-    for (j in seq_len(ncol(idx))) {
-      raw <- raw_index[idx[, j]]
-      if (isTRUE(plan$agg$weighted)) {
-        w <- block$w[, j]
-        denominator <- sum(w)
-        if (any(!is.finite(w)) || denominator == 0) {
-          return(NULL)
-        }
-        w <- w / denominator
-      } else {
-        w <- rep.int(1 / length(raw), length(raw))
-      }
-      w_hi <- if (is.null(d_hi)) w else w * d_hi[raw]
-      w_lo <- if (is.null(d_lo)) w else w * d_lo[raw]
-      value <- jacobian_analytic_weighted_columns(X_hi, raw, w_hi) -
-        jacobian_analytic_weighted_columns(X_lo, raw, w_lo)
-      out[block$cols[j], ] <- value
-    }
+  # The aggregation weights are recorded against comparison rows, so map them
+  # through to the model matrix rows those comparisons were built from and
+  # contract hi and lo separately. Group by group this would subset X_hi and
+  # X_lo once each per group, copying both matrices in full across the loop;
+  # as a single sparse contraction it is one pass over each.
+  weights <- jacobian_analytic_aggregate_weights(plan$agg, length(raw_index))
+  if (is.null(weights)) {
+    return(NULL)
   }
-  list(J = out, aggregated = TRUE)
+  rows <- raw_index[weights$rows]
+  vals_hi <- if (is.null(d_hi)) weights$vals else weights$vals * d_hi[rows]
+  vals_lo <- if (is.null(d_lo)) weights$vals else weights$vals * d_lo[rows]
+  if (!all(is.finite(vals_hi)) || !all(is.finite(vals_lo))) {
+    return(NULL)
+  }
+  jacobian_analytic_aggregate_contract(
+    X_hi, plan$agg, rows, weights$cols, vals_hi
+  ) -
+    jacobian_analytic_aggregate_contract(
+      X_lo, plan$agg, rows, weights$cols, vals_lo
+    )
 }
 
 
-#' Get an exact analytic Jacobian when supported
+#' How this model's predictions depend on its coefficients
+#'
+#' The whole model-specific half of the analytic Jacobian contract. A method
+#' answers three questions and nothing else: is this exact class eligible,
+#' does this prediction `type` live on the link scale or the response scale,
+#' and -- on the response scale -- which family supplies `linkinv()` and
+#' `mu.eta()`. Everything downstream of that (matrix alignment, comparison
+#' gradients, aggregation, hypothesis pullback, replay validation) is
+#' model-agnostic and belongs to `compute_analytic_plan_jacobian()`.
+#'
+#' The derivative of the predictions with respect to the coefficients is the
+#' model matrix `X` on the link scale, and `X` scaled row-wise by
+#' `family$mu.eta(eta)` on the response scale. A spec is exactly the
+#' information needed to say which of the two applies.
+#'
 #' @param model A model object.
-#' @param ... Arguments passed to model-specific methods.
-#' @return A numeric Jacobian matrix, or `NULL` when the model or estimand is
-#'   not eligible for the analytic path.
+#' @param type The prediction type requested by the estimand.
+#' @param ... Unused; present for method extension.
+#' @return `NULL` when the model or the requested `type` is not eligible,
+#'   otherwise a list with `response_scale` (a scalar logical) and `family`
+#'   (a family object on the response scale, `NULL` on the link scale).
 #' @keywords internal
 #' @noRd
-get_jacobian_analytic <- function(model, ...) {
-  UseMethod("get_jacobian_analytic", model)
+get_prediction_jacobian_spec <- function(model, type, ...) {
+  UseMethod("get_prediction_jacobian_spec", model)
 }
 
 
 #' @noRd
 #' @export
-get_jacobian_analytic.default <- function(model, ...) {
+get_prediction_jacobian_spec.default <- function(model, type, ...) {
   NULL
 }
 
 
-jacobian_analytic_model_matrix <- function(
+# Shared bodies for the per-model get_prediction_jacobian_spec() methods. Each
+# method gates on its exact class -- subclasses may override prediction
+# behavior the eligibility whitelist knows nothing about -- and on the
+# prediction types whose scale it can differentiate.
+prediction_jacobian_spec_linear <- function(model, class_expected, type, types_ok) {
+  if (
+    !identical(class(model)[1], class_expected) ||
+      !isTRUE(type %in% types_ok)
+  ) {
+    return(NULL)
+  }
+  list(response_scale = FALSE, family = NULL)
+}
+
+
+prediction_jacobian_spec_glm_family <- function(
+  model,
+  class_expected,
+  type,
+  response_type = "response",
+  link_type = "link",
+  family = NULL
+) {
+  if (
+    !identical(class(model)[1], class_expected) ||
+      !isTRUE(type %in% c(response_type, link_type))
+  ) {
+    return(NULL)
+  }
+  if (!identical(type, response_type)) {
+    return(list(response_scale = FALSE, family = NULL))
+  }
+  if (is.null(family)) {
+    family <- stats::family(model)
+  }
+  list(response_scale = TRUE, family = family)
+}
+
+
+#' Get an exact analytic Jacobian when supported
+#' @param model A model object.
+#' @param type The prediction type requested by the estimand.
+#' @param ... Arguments passed on to the composer.
+#' @return A numeric Jacobian matrix, or `NULL` when the model or estimand is
+#'   not eligible for the analytic path.
+#' @keywords internal
+#' @noRd
+get_jacobian_analytic <- function(model, type, ...) {
+  UseMethod("get_jacobian_analytic", model)
+}
+
+
+# The entry point is model-agnostic: it asks the model how its predictions
+# depend on its coefficients, and hands that answer to the composer. The
+# generic is kept so that a model class which needs to bypass the spec
+# contract entirely still can, but no method in this package does.
+#' @noRd
+#' @export
+get_jacobian_analytic.default <- function(model, type, ...) {
+  spec <- get_prediction_jacobian_spec(model, type = type)
+  if (is.null(spec)) {
+    return(NULL)
+  }
+  compute_analytic_plan_jacobian(spec = spec, model = model, type = type, ...)
+}
+
+
+# Model-agnostic composition of a prediction-derivative spec with an estimand
+# plan. `spec` is whatever get_prediction_jacobian_spec() returned; nothing
+# else here knows anything about the model class.
+compute_analytic_plan_jacobian <- function(
+  spec,
   model,
   plan,
   kind,
   type,
   estimate,
-  contrast_data = NULL,
-  response_scale = FALSE,
-  family = NULL
+  contrast_data = NULL
 ) {
+  response_scale <- isTRUE(spec$response_scale)
+  family <- if (response_scale) spec$family else NULL
   # NULL means that this estimand is not safely eligible. This is an expected
-  # result which preserves the existing autodiff and finite-difference paths.
+  # result which preserves the existing finite-difference path.
   tryCatch(
     {
       if (is.null(plan) || model_has_effective_offset(model)) {
@@ -258,10 +494,11 @@ jacobian_analytic_model_matrix <- function(
         return(NULL)
       }
 
+      # A non-matrix hypothesis no longer disqualifies the estimand: it is a
+      # separate stage, composed after the fact by jacobian_analytic_hypothesis().
       if (
         !kind %in% c("comparisons", "predictions") ||
-          !identical(plan$kind, kind) ||
-          (!is.null(plan$hyp) && !identical(plan$hyp$kind, "matrix"))
+          !identical(plan$kind, kind)
       ) {
         return(NULL)
       }
@@ -269,7 +506,7 @@ jacobian_analytic_model_matrix <- function(
       align_matrix <- function(X) {
         if (
           !isTRUE(checkmate::check_matrix(X, mode = "numeric")) ||
-            ncol(X) != length(beta) || any(!is.finite(X))
+            ncol(X) != length(beta) || !matrix_all_finite(X)
         ) {
           return(NULL)
         }
@@ -288,18 +525,35 @@ jacobian_analytic_model_matrix <- function(
       }
 
       if (identical(kind, "comparisons")) {
-        if (
-          is.null(contrast_data) || isTRUE(plan$need_y) ||
-            length(plan$groups) == 0L
-        ) {
+        if (is.null(contrast_data) || length(plan$groups) == 0L) {
           return(NULL)
         }
-        group_ok <- vapply(plan$groups, function(g) {
-          g$fun_key %in% c("difference", "differenceavg", "differenceavgwts") &&
-            !isTRUE(g$uses_y)
-        }, logical(1))
-        if (!all(group_ok)) {
+        # `plan$need_y` is set for every custom comparison function, because a
+        # user function might accept `y`. Whether it actually does is recorded
+        # per group, and that is the condition which matters here: a group
+        # which ignores the observed outcome has a derivative that does not
+        # depend on it.
+        if (plan_groups_use_y(plan)) {
           return(NULL)
+        }
+        # Recorded differences have closed-form derivatives. Any other
+        # comparison function is handled as its own stage further down.
+        difference_groups <- all(vapply(plan$groups, function(g) {
+          isTRUE(g$fun_key %in% c("difference", "differenceavg", "differenceavgwts"))
+        }, logical(1)))
+        # A group whose function has no recorded closed form -- a custom
+        # closure, or any key outside the derivative registry -- can only end
+        # in rejection, so reject it here, before the model matrices are
+        # scanned and aligned. This is the statically obvious case; every
+        # data-dependent rejection stays where the data is.
+        if (!difference_groups) {
+          supported <- vapply(plan$groups, function(g) {
+            key <- g$fun_key
+            is.character(key) && length(key) == 1L && !is.na(key)
+          }, logical(1))
+          if (!all(supported)) {
+            return(NULL)
+          }
         }
         X_hi <- align_matrix(attr(
           contrast_data$hi,
@@ -313,42 +567,39 @@ jacobian_analytic_model_matrix <- function(
           return(NULL)
         }
 
-        reuse <- isTRUE(plan$model_matrix_used) &&
-          identical(colnames(X_hi), beta_names) &&
-          identical(colnames(X_lo), beta_names) &&
-          is.numeric(plan$baseline_hi) &&
-          length(plan$baseline_hi) == nrow(X_hi) &&
-          is.numeric(plan$baseline_lo) &&
-          length(plan$baseline_lo) == nrow(X_lo)
-        eta_reuse <- reuse &&
-          is.numeric(plan$eta_hi) && length(plan$eta_hi) == nrow(X_hi) &&
-          is.numeric(plan$eta_lo) && length(plan$eta_lo) == nrow(X_lo)
-        if (isTRUE(response_scale) && !eta_reuse) {
-          eta_hi <- drop(X_hi %*% beta)
-          eta_lo <- drop(X_lo %*% beta)
-        } else if (eta_reuse) {
-          eta_hi <- plan$eta_hi
-          eta_lo <- plan$eta_lo
-        }
-        if (reuse) {
-          pred_hi <- plan$baseline_hi
-          pred_lo <- plan$baseline_lo
-        } else {
-          eta_hi <- drop(X_hi %*% beta)
-          eta_lo <- drop(X_lo %*% beta)
-          pred_hi <- if (isTRUE(response_scale)) family$linkinv(eta_hi) else eta_hi
-          pred_lo <- if (isTRUE(response_scale)) family$linkinv(eta_lo) else eta_lo
-        }
-        if (isTRUE(response_scale)) {
-          d_hi <- as.vector(family$mu.eta(eta_hi))
-          d_lo <- as.vector(family$mu.eta(eta_lo))
-        } else {
-          d_hi <- NULL
-          d_lo <- NULL
+        scale_hi <- jacobian_analytic_scale(
+          X_hi,
+          beta,
+          plan$baseline_hi,
+          plan$eta_hi,
+          plan$model_matrix_used,
+          response_scale,
+          family
+        )
+        scale_lo <- jacobian_analytic_scale(
+          X_lo,
+          beta,
+          plan$baseline_lo,
+          plan$eta_lo,
+          plan$model_matrix_used,
+          response_scale,
+          family
+        )
+        pred_hi <- scale_hi$pred
+        pred_lo <- scale_lo$pred
+        d_hi <- scale_hi$d
+        d_lo <- scale_lo$d
+        # The replay stages tolerate missing predictions (their aggregation
+        # averages with na.rm = TRUE), but the sparse Jacobian aggregation
+        # divides by full group counts. Those two conventions agree only when
+        # nothing is missing, so missing predictions disqualify the analytic
+        # path outright.
+        if (anyNA(pred_hi) || anyNA(pred_lo)) {
+          return(NULL)
         }
         # Validate predictions on the effective scale before transforming the
         # derivative matrix with the recorded comparison operations.
-        replay <- comparison_plan_apply(plan, pred_hi, pred_lo)
+        replay <- comparison_plan_apply_stages(plan, pred_hi, pred_lo)
       } else {
         X <- align_matrix(attr(
           plan$predict_args$newdata,
@@ -357,43 +608,39 @@ jacobian_analytic_model_matrix <- function(
         if (is.null(X)) {
           return(NULL)
         }
-        reuse <- isTRUE(plan$model_matrix_used) &&
-          identical(colnames(X), beta_names) &&
-          is.numeric(plan$baseline_prediction) &&
-          length(plan$baseline_prediction) == nrow(X)
-        eta_reuse <- reuse &&
-          is.numeric(plan$linear_predictor) &&
-          length(plan$linear_predictor) == nrow(X)
-        if (isTRUE(response_scale) && !eta_reuse) {
-          eta <- drop(X %*% beta)
-        } else if (eta_reuse) {
-          eta <- plan$linear_predictor
+        # The row scaling stays a vector for now. Whether it ever needs to
+        # meet X as a full matrix depends on the aggregation, decided below.
+        scale_pred <- jacobian_analytic_scale(
+          X,
+          beta,
+          plan$baseline_prediction,
+          plan$linear_predictor,
+          plan$model_matrix_used,
+          response_scale,
+          family
+        )
+        pred <- scale_pred$pred
+        d_pred <- scale_pred$d
+        # Same rejection as the comparisons branch: replay aggregation drops
+        # missing predictions, the sparse weights do not.
+        if (isTRUE(plan$has_na) || anyNA(pred)) {
+          return(NULL)
         }
-        if (reuse) {
-          pred <- plan$baseline_prediction
-        } else {
-          eta <- drop(X %*% beta)
-          pred <- if (isTRUE(response_scale)) family$linkinv(eta) else eta
-        }
-        if (isTRUE(response_scale)) {
-          J <- X * as.vector(family$mu.eta(eta))
-        } else {
-          J <- X
-        }
-        replay <- prediction_plan_apply(plan, pred)
+        replay <- prediction_plan_apply_stages(plan, pred)
       }
 
       # This is a fail-closed correctness guard, not a debugging assertion. It
       # rejects stale matrices, offsets, prediction arguments, and future
       # semantic changes which are not captured by the static whitelist above.
-      if (!isTRUE(all.equal(
-        replay,
-        estimate,
-        tolerance = sqrt(.Machine$double.eps),
-        check.attributes = FALSE
-      ))) {
+      # The comparison is element-wise: a mean-relative check would let one
+      # wrong row hide among many correct ones.
+      if (!plan_replay_agrees(replay$post, estimate)) {
         return(NULL)
       }
+
+      # Set by whichever branch below folds the recorded aggregation into the
+      # Jacobian it builds, so that it is not applied a second time.
+      aggregated_early <- FALSE
 
       if (identical(kind, "comparisons")) {
         if (!is.null(plan$na_keep)) {
@@ -401,52 +648,85 @@ jacobian_analytic_model_matrix <- function(
           X_lo <- X_lo[plan$na_keep, , drop = FALSE]
           if (!is.null(d_hi)) d_hi <- d_hi[plan$na_keep]
           if (!is.null(d_lo)) d_lo <- d_lo[plan$na_keep]
+          pred_hi <- pred_hi[plan$na_keep]
+          pred_lo <- pred_lo[plan$na_keep]
         }
         if (!is.null(plan$perm)) {
           X_hi <- X_hi[plan$perm, , drop = FALSE]
           X_lo <- X_lo[plan$perm, , drop = FALSE]
           if (!is.null(d_hi)) d_hi <- d_hi[plan$perm]
           if (!is.null(d_lo)) d_lo <- d_lo[plan$perm]
+          pred_hi <- pred_hi[plan$perm]
+          pred_lo <- pred_lo[plan$perm]
         }
 
-        direct <- jacobian_analytic_comparison_aggregate(
-          X_hi = X_hi,
-          X_lo = X_lo,
-          d_hi = d_hi,
-          d_lo = d_lo,
-          plan = plan
-        )
-        if (is.null(direct)) {
-          aggregated_early <- FALSE
-          if (isTRUE(response_scale)) {
-            J <- X_hi * d_hi - X_lo * d_lo
-          } else {
-            J <- X_hi - X_lo
-          }
+        # Rowwise differences feeding a recorded aggregation fold straight
+        # into the aggregation weights and come back already contracted.
+        # Every other group shape goes through the exact per-group gradients:
+        # they hand the stage its model matrices and inverse-link derivatives
+        # separately rather than the pair of prediction Jacobians, so a group
+        # which aggregates its rows composes them without ever forming an
+        # observation-level derivative either.
+        direct <- if (isTRUE(difference_groups)) {
+          jacobian_analytic_comparison_aggregate(
+            X_hi = X_hi,
+            X_lo = X_lo,
+            d_hi = d_hi,
+            d_lo = d_lo,
+            plan = plan
+          )
         } else {
-          J <- direct$J
-          aggregated_early <- direct$aggregated
+          NULL
         }
-        if (is.null(direct)) {
-          J <- jacobian_analytic_comparison_groups(J, plan)
+        if (!is.null(direct)) {
+          J <- direct
+          aggregated_early <- TRUE
+        } else {
+          J <- jacobian_analytic_comparison_exact(
+            X_hi = X_hi,
+            X_lo = X_lo,
+            d_hi = d_hi,
+            d_lo = d_lo,
+            pred_hi = pred_hi,
+            pred_lo = pred_lo,
+            plan = plan
+          )
           if (is.null(J)) {
             return(NULL)
           }
           if (!is.null(plan$est_keep)) {
             J <- J[plan$est_keep, , drop = FALSE]
           }
+          aggregated_early <- FALSE
         }
-      } else if (!is.null(plan$keep)) {
-        J <- J[plan$keep, , drop = FALSE]
+      } else {
+        # An aggregating estimand contracts the prediction rows away, so the
+        # observation-level Jacobian is an intermediate the answer never needs.
+        # Row subsetting would renumber the recorded aggregation indices, so
+        # the shortcut is taken only when there is nothing to subset.
+        direct <- if (is.null(plan$keep)) {
+          jacobian_analytic_aggregate_direct(X, d_pred, plan$agg)
+        } else {
+          NULL
+        }
+        if (is.null(direct)) {
+          J <- if (is.null(d_pred)) X else X * d_pred
+          if (!is.null(plan$keep)) {
+            J <- J[plan$keep, , drop = FALSE]
+          }
+        } else {
+          J <- direct
+          aggregated_early <- TRUE
+        }
       }
 
-      if (!identical(kind, "comparisons") || !isTRUE(aggregated_early)) {
+      if (!isTRUE(aggregated_early)) {
         J <- jacobian_analytic_aggregate(J, plan$agg)
         if (is.null(J)) {
           return(NULL)
         }
       }
-      J <- jacobian_analytic_hypothesis(J, plan$hyp)
+      J <- jacobian_analytic_hypothesis(J, plan$hyp, replay$pre)
       if (is.null(J)) {
         return(NULL)
       }
@@ -454,12 +734,27 @@ jacobian_analytic_model_matrix <- function(
       if (nrow(J) != length(estimate)) {
         return(NULL)
       }
+      # Final guard on the output. The inputs were already screened by
+      # align_matrix(), so this is a backstop for non-finite values produced
+      # by the composition itself (an inverse-link derivative overflowing, a
+      # gradient at a pole). It is a backstop and not the sole guard because
+      # IEEE propagation is a property of IEEE arithmetic, not of every BLAS
+      # kernel: implementations which skip zero multiplicands can turn
+      # 0 * Inf into 0 instead of NaN, so an Inf in a zero-weighted input row
+      # is not guaranteed to surface here.
+      if (!matrix_all_finite(J)) {
+        return(NULL)
+      }
       # Cached model matrices may carry terms metadata such as `assign` and
       # `contrasts`. A Jacobian's contract includes only dimensions and names.
+      numeric_stage <- isTRUE(attr(J, "marginaleffects_numeric_stage"))
       attributes(J) <- list(
         dim = dim(J),
         dimnames = list(NULL, beta_names)
       )
+      if (numeric_stage) {
+        attr(J, "marginaleffects_numeric_stage") <- TRUE
+      }
 
       J
     },

--- a/r/R/get_model_matrix.R
+++ b/r/R/get_model_matrix.R
@@ -18,29 +18,48 @@ get_model_matrix.default <- function(model, newdata, mfx = NULL) {
 
 
 model_has_effective_offset <- function(model) {
-    offset <- model[["offset"]]
+    # The terms and call are consulted before the stored $offset component,
+    # not after it: several supported classes (quantreg::rq, rms::ols) fit
+    # formula offsets without ever storing an $offset element, so gating on
+    # the component would skip the formula check in exactly the case it
+    # exists for.
+    tt <- tryCatch(stats::terms(model), error = function(e) NULL)
+    if (length(attr(tt, "offset")) > 0L) {
+        return(TRUE)
+    }
+    cl <- tryCatch(model$call, error = function(e) NULL)
+    # An explicit `offset = NULL` argument is stored in the call but names no
+    # offset; only a non-NULL argument disqualifies.
+    if ("offset" %in% names(cl) && !is.null(cl[["offset"]])) {
+        return(TRUE)
+    }
+    offset <- tryCatch(model[["offset"]], error = function(e) NULL)
     if (is.null(offset)) {
         return(FALSE)
     }
-    tt <- tryCatch(stats::terms(model), error = function(e) NULL)
-    formula_offset <- length(attr(tt, "offset")) > 0L
-    call_offset <- "offset" %in% names(model$call)
-    malformed_or_nonzero <-
-        !is.numeric(offset) || anyNA(offset) || any(offset != 0)
-    formula_offset || call_offset || malformed_or_nonzero
+    !is.numeric(offset) || anyNA(offset) || any(offset != 0)
 }
 
 
 #' Add model matrix attribute to newdata
 #' @param mfx marginaleffects object
 #' @param newdata data frame to add attributes to
+#' @param model model object; used only when `mfx` is unavailable
 #' @keywords internal
 #' @noRd
-add_model_matrix_attribute <- function(mfx, newdata = NULL) {
-    model <- mfx@model
+add_model_matrix_attribute <- function(mfx = NULL, newdata = NULL, model = NULL) {
+    if (is.null(model)) {
+        if (is.null(mfx)) {
+            return(newdata)
+        }
+        model <- mfx@model
+    }
 
     # predictions() only passes mfx; comparisons() passes mfx and hi/lo
     if (is.null(newdata)) {
+        if (is.null(mfx)) {
+            return(newdata)
+        }
         newdata <- mfx@newdata
     }
 
@@ -70,11 +89,17 @@ add_model_matrix_attribute <- function(mfx, newdata = NULL) {
     }
 
     # subset variables for listwise deletion
-    vars <- unlist(mfx@variable_names_predictors, use.names = FALSE)
-    vars <- c(vars, unlist(mfx@variable_names_response, use.names = FALSE))
-    vars <- intersect(vars, colnames(newdata))
-
-    nd <- as.data.frame(newdata)[, vars, drop = FALSE]
+    if (is.null(mfx)) {
+        # Exact lm/glm retries can let their terms object select the required
+        # columns directly, without propagating the full marginaleffects state
+        # through every model-specific prediction method.
+        nd <- as.data.frame(newdata)
+    } else {
+        vars <- unlist(mfx@variable_names_predictors, use.names = FALSE)
+        vars <- c(vars, unlist(mfx@variable_names_response, use.names = FALSE))
+        vars <- intersect(vars, colnames(newdata))
+        nd <- as.data.frame(newdata)[, vars, drop = FALSE]
+    }
 
     # This cache is optional. Model-specific matrix methods should fail closed
     # without paying the connection overhead of hush()/capture.output().
@@ -95,5 +120,47 @@ add_model_matrix_attribute <- function(mfx, newdata = NULL) {
     }
 
     attr(newdata, "marginaleffects_model_matrix") <- MM
+    return(newdata)
+}
+
+
+#' Attach a model matrix to a data frame which is not `mfx@newdata`
+#'
+#' The matrix builder reads `mfx@newdata`, so a frame which is not currently
+#' held there is attached by swapping it in on a local copy of `mfx`.
+#' @keywords internal
+#' @noRd
+add_model_matrix_attribute_data <- function(mfx, data) {
+    mfx@newdata <- data
+    add_model_matrix_attribute(mfx)
+}
+
+
+#' Attach a model matrix after `stats::predict()` failed
+#'
+#' `get_predict()` methods that can compute a linear predictor from
+#' `X %*% beta` call this to build the model matrix on demand, rather than
+#' giving up on the error raised by `stats::predict()`. When no usable matrix
+#' can be built, the original error is re-raised so unrelated failures keep
+#' their own message.
+#'
+#' @param model model object
+#' @param newdata data frame to add attributes to
+#' @param beta coefficient vector the matrix columns must match
+#' @param error condition raised by `stats::predict()`
+#' @keywords internal
+#' @noRd
+model_matrix_retry <- function(model, newdata, beta, error) {
+    if (!isTRUE(class(model)[1] %in% c("lm", "glm"))) {
+        stop(error)
+    }
+    newdata <- add_model_matrix_attribute(
+        newdata = newdata,
+        model = model
+    )
+    MM <- attr(newdata, "marginaleffects_model_matrix")
+    if (!isTRUE(checkmate::check_matrix(MM)) || ncol(MM) != length(beta)) {
+        stop(error)
+    }
     return(newdata)
 }

--- a/r/R/get_se_delta.R
+++ b/r/R/get_se_delta.R
@@ -1,4 +1,62 @@
+# Reorder a named covariance matrix to coefficient order. A matrix whose
+# names are a permutation of the coefficient names is reordered; a matrix
+# with complete unique names which are not a permutation is an error, because
+# every downstream consumer multiplies positionally and equal dimensions would
+# hide the mismatch. Unnamed or partially named matrices pass through: with no
+# names there is nothing to align by, and rejecting them would break models
+# whose vcov methods return bare matrices.
+align_vcov_to_coef <- function(V, model, ...) {
+    vnames <- colnames(V)
+    if (is.null(vnames) || anyDuplicated(vnames) > 0L) {
+        return(V)
+    }
+    beta <- tryCatch(get_coef(model, ...), error = function(e) NULL)
+    bnames <- names(beta)
+    if (is.null(bnames) || anyDuplicated(bnames) > 0L) {
+        return(V)
+    }
+    rnames <- rownames(V)
+    if (!is.null(rnames) && !identical(rnames, vnames)) {
+        stop_sprintf(
+            "The supplied variance-covariance matrix has row names which differ from its column names."
+        )
+    }
+    if (setequal(vnames, bnames)) {
+        if (!identical(vnames, bnames)) {
+            # Index positionally by matched columns: row names may be absent,
+            # and name-indexing rows would fail with an uninformative
+            # subscript error.
+            idx <- match(bnames, vnames)
+            V <- V[idx, idx, drop = FALSE]
+            dimnames(V) <- list(bnames, bnames)
+        }
+        return(V)
+    }
+    if (ncol(V) == length(beta)) {
+        stop_sprintf(
+            "The supplied variance-covariance matrix has the same dimension as the coefficient vector, but its names do not match the coefficient names."
+        )
+    }
+    V
+}
+
+
 align_jacobian_vcov <- function(J, V, object, ...) {
+    # Equal dimensions with matching name sets still need reordering: without
+    # it the multiplication downstream is positional and silently wrong for a
+    # permuted matrix.
+    jnames <- colnames(J)
+    vnames <- colnames(V)
+    if (
+        !is.null(jnames) && !is.null(vnames) &&
+            anyDuplicated(jnames) == 0L && anyDuplicated(vnames) == 0L &&
+            setequal(jnames, vnames)
+    ) {
+        if (!identical(jnames, vnames)) {
+            V <- V[jnames, jnames, drop = FALSE]
+        }
+        return(list(J = J, V = V))
+    }
     if (!isTRUE(ncol(J) == ncol(V))) {
         beta <- get_coef(object, ...)
         # Issue #718: ordinal::clm in test-pkg-ordinal.R
@@ -25,15 +83,18 @@ align_jacobian_vcov <- function(J, V, object, ...) {
 
 
 std_error_from_jacobian <- function(J, V, object, ...) {
-    # Covariance propagation is shared algebra. Eligibility for analytic and
-    # autodiff Jacobians remains independent of this helper.
+    # Covariance propagation is shared algebra. Eligibility for the analytic
+    # Jacobian remains independent of this helper.
     jnames <- colnames(J)
     vnames <- colnames(V)
     if (
         !is.null(jnames) && !is.null(vnames) &&
+            !identical(jnames, vnames) &&
             anyDuplicated(jnames) == 0L && anyDuplicated(vnames) == 0L &&
             setequal(jnames, vnames)
     ) {
+        # Reorder only when the orders actually differ: subsetting an
+        # already-aligned matrix copies p x p doubles for nothing.
         V <- V[jnames, jnames, drop = FALSE]
     }
     if (!isTRUE(ncol(J) == ncol(V))) {
@@ -43,22 +104,43 @@ std_error_from_jacobian <- function(J, V, object, ...) {
     }
 
     # Avoid constructing the full J V J' matrix when only its diagonal is used.
-    se <- sqrt(rowSums(tcrossprod(J, V) * J))
-    se[se == 0] <- NA_real_
+    variances <- rowSums(tcrossprod(J, V) * J)
+    # tiny negative variances are floating-point noise: clamp them to zero
+    scale <- suppressWarnings(max(abs(variances), na.rm = TRUE))
+    if (!is.finite(scale)) {
+        scale <- 0
+    }
+    tol <- sqrt(.Machine$double.eps) * max(1, scale)
+    variances[variances < 0 & variances > -tol] <- 0
+    se <- sqrt(variances)
+    # A zero here is a statement, not a failure: a constant estimand -- a
+    # contrast of a level with itself, a zero row of an exact Jacobian -- has
+    # variance exactly zero. Test statistics on such rows are undefined and
+    # come out NaN downstream, which is the correct separate signal. The
+    # clamping above is deliberately kept separate: it removes negative noise
+    # without turning an exact zero into a missing value.
     list(std.error = se, jacobian = J)
 }
 
 
-#' Compute standard errors using the delta method
+#' Jacobian of a delta method estimand with respect to model coefficients
+#'
+#' Covariance propagation is deliberately left to the caller: the unconditional
+#' variance path needs this derivative without ever forming a coefficient
+#' covariance matrix, and the plan-based delta method propagates the composed
+#' derivative rather than this one.
 #'
 #' @inheritParams slopes
 #' @param FUN a function which accepts a `model` and other inputs and returns a
 #'   vector of estimates (marginal effects, marginal means, etc.)
-#' @return vector of standard errors
+#' @param vcov accepted and ignored, so that callers can build a single
+#'   argument list for this function and for [get_se_delta()].
+#' @return `NULL` when the model admits no delta method, otherwise a list with
+#'   the `jacobian`, the `method` which produced it ("custom" or "numeric"),
+#'   and the `coefs` it was differentiated at.
 #' @noRd
-get_se_delta <- function(
+get_delta_jacobian <- function(
     model_perturbed,
-    vcov,
     FUN,
     mfx = NULL,
     type = NULL,
@@ -73,6 +155,7 @@ get_se_delta <- function(
     lo = NULL,
     original = NULL,
     estimates = NULL,
+    vcov = NULL,
     ...) {
     # Use mfx slots when available
     if (!is.null(mfx)) {
@@ -89,21 +172,7 @@ get_se_delta <- function(
 
     coefs <- get_coef(model_perturbed, ...)
 
-    # some vcov methods return an unnamed matrix, some have duplicate names
-    flag <- anyDuplicated(colnames(vcov)) == 0 &&
-        anyDuplicated(names(coefs)) == 0
-    if (
-        flag &&
-            !is.null(dimnames(vcov)) &&
-            all(names(coefs) %in% colnames(vcov))
-    ) {
-        bnames <- intersect(names(coefs), colnames(vcov))
-        vcov <- vcov[bnames, bnames, drop = FALSE]
-        colnames(vcov) <- row.names(vcov) <- names(coefs)
-        coefs <- coefs[bnames]
-    }
-
-    # user-supplied jacobian machine (e.g. JAX)
+    # user-supplied jacobian machine
     if (is.null(J)) {
         fun <- settings_get("jacobian_function")
         if (is.null(fun)) {
@@ -130,8 +199,8 @@ get_se_delta <- function(
         )
         checkmate::assert_matrix(J, mode = "numeric", ncols = length(coefs), null.ok = TRUE)
 
-        # Unpad Jacobian for autodiff jax_jacobian if newdata was padded
-        # JAX computes jacobian on padded newdata, but final results are unpadded
+        # A user-supplied jacobian function computes on `mfx@newdata`, which
+        # may be padded; the reported results are not. Drop the padded rows.
         if (!is.null(J) && !is.null(mfx) && "rowid" %in% colnames(mfx@newdata)) {
             idx <- mfx@newdata$rowid > 0
             if (!all(idx) && nrow(J) == nrow(mfx@newdata)) {
@@ -185,7 +254,13 @@ get_se_delta <- function(
         return(g)
     }
 
-    if (is.null(J) || !is.null(hypothesis)) {
+    # A matrix returned by the user's `marginaleffects_jacobian_function` is
+    # authoritative for the whole pipeline, hypothesis included: the function
+    # receives the `hypothesis` argument above, so recomputing here would both
+    # discard the user's work and misreport its provenance. Only a NULL return
+    # falls back to numerical differentiation.
+    method <- if (is.null(J)) "numeric" else "custom"
+    if (is.null(J)) {
         args <- list(
             func = inner,
             x = coefs,
@@ -195,9 +270,80 @@ get_se_delta <- function(
         colnames(J) <- names(coefs)
     }
 
-    propagated <- std_error_from_jacobian(J, vcov, model_perturbed, ...)
+    list(jacobian = J, method = method, coefs = coefs)
+}
+
+
+#' Compute standard errors using the delta method
+#'
+#' @inheritParams slopes
+#' @param FUN a function which accepts a `model` and other inputs and returns a
+#'   vector of estimates (marginal effects, marginal means, etc.)
+#' @return vector of standard errors
+#' @noRd
+get_se_delta <- function(
+    model_perturbed,
+    vcov,
+    FUN,
+    mfx = NULL,
+    type = NULL,
+    newdata = NULL,
+    eps = NULL,
+    J = NULL,
+    hypothesis = NULL,
+    calling_function = NULL,
+    comparison = NULL,
+    by = NULL,
+    hi = NULL,
+    lo = NULL,
+    original = NULL,
+    estimates = NULL,
+    ...) {
+    jac <- get_delta_jacobian(
+        model_perturbed = model_perturbed,
+        FUN = FUN,
+        mfx = mfx,
+        type = type,
+        newdata = newdata,
+        eps = eps,
+        J = J,
+        hypothesis = hypothesis,
+        calling_function = calling_function,
+        comparison = comparison,
+        by = by,
+        hi = hi,
+        lo = lo,
+        original = original,
+        estimates = estimates,
+        ...
+    )
+    if (is.null(jac)) {
+        return(NULL)
+    }
+    coefs <- jac$coefs
+
+    # some vcov methods return an unnamed matrix, some have duplicate names
+    flag <- anyDuplicated(colnames(vcov)) == 0 &&
+        anyDuplicated(names(coefs)) == 0
+    if (
+        flag &&
+            !is.null(dimnames(vcov)) &&
+            all(names(coefs) %in% colnames(vcov))
+    ) {
+        bnames <- intersect(names(coefs), colnames(vcov))
+        vcov <- vcov[bnames, bnames, drop = FALSE]
+        colnames(vcov) <- row.names(vcov) <- names(coefs)
+    }
+
+    propagated <- std_error_from_jacobian(
+        jac$jacobian,
+        vcov,
+        model_perturbed,
+        ...
+    )
     se <- propagated$std.error
     attr(se, "jacobian") <- propagated$jacobian
+    attr(se, "jacobian_source") <- jac$method
 
     return(se)
 }

--- a/r/R/get_vcov.R
+++ b/r/R/get_vcov.R
@@ -19,6 +19,13 @@ get_vcov.default <- function(model, vcov = NULL, ...) {
 
     vcov <- sanitize_vcov(model = model, vcov = vcov)
     if (isTRUE(checkmate::check_matrix(vcov))) {
+        # A user-supplied matrix is stored and reused in several places: the
+        # delta method, the vcov() extractor, and simulation draws. Aligning
+        # it to coefficient order once, here, keeps every consumer positional
+        # thereafter. The delta method re-aligned locally and was correct, but
+        # the stored matrix reached the other consumers in user order, where
+        # equal dimensions silently multiplied positionally.
+        vcov <- align_vcov_to_coef(vcov, model, ...)
         return(vcov)
     }
 
@@ -119,9 +126,19 @@ get_varcov_args <- function(model, vcov) {
         }
     }
 
+    # `switch()` errors outright on anything but a length-1 vector, so only the
+    # string shorthands go through it. Everything else takes the same route the
+    # default branch would have taken.
+    if (!is.character(vcov) || length(vcov) != 1L || is.na(vcov)) {
+        return(list(vcov = vcov))
+    }
+
     out <- switch(
         vcov,
-        "stata" = list(vcov = "HC2"),
+        # Stata's `regress, vce(robust)` is HC1: HC0 rescaled by n / (n - k).
+        # estimatr's se_type = "stata" and modelsummary's "stata" shortcut
+        # agree. This was HC2 until 2026-08, which matched no Stata estimator.
+        "stata" = list(vcov = "HC1"),
         "robust" = list(vcov = "HC3"),
         "bootstrap" = list(vcov = "BS"),
         "outer-product" = list(vcov = "OPG"),

--- a/r/R/hypotheses.R
+++ b/r/R/hypotheses.R
@@ -159,12 +159,26 @@ hypotheses <- function(
     multcomp = FALSE,
     numderiv = "fdforward",
     ...) {
+    vcov <- sanitize_vcov_request(vcov)
     call <- construct_call(model, "hypotheses")
 
     # Early validation and setup
     if (is.null(model)) model <- ...get("model_perturbed")
     if (is.null(model)) stop_sprintf("`model` is missing.")
     sanity_multcomp(multcomp, hypothesis, joint)
+    internal_classes <- c("predictions", "comparisons", "slopes", "hypotheses")
+    if (inherits(model, internal_classes) && !isTRUE(checkmate::check_flag(vcov))) {
+        msg <- paste0(
+            "The `vcov` argument is not available when `model` is a ",
+            "`predictions`, `comparisons`, `slopes`, or `hypotheses` object. ",
+            "Please specify the type of standard errors in the initial ",
+            "`marginaleffects` call."
+        )
+        stop_sprintf(msg)
+    }
+    if (inherits(vcov, "marginaleffects_vcov_unconditional")) {
+        stop_unconditional("hypotheses")
+    }
 
     # Early returns for special cases - removed mice check, moved later
 
@@ -180,13 +194,7 @@ hypotheses <- function(
     }
 
     # Handle marginaleffects objects vs regular models
-    internal_classes <- c("predictions", "comparisons", "slopes", "hypotheses")
     if (inherits(model, internal_classes)) {
-        if (!isTRUE(checkmate::check_flag(vcov))) {
-            stop_sprintf(
-                "The `vcov` argument is not available when `model` is a `predictions`, `comparisons`, `slopes`, or `hypotheses` object. Please specify the type of standard errors in the initial `marginaleffects` call."
-            )
-        }
         mfx <- components(model, "all")
         if (!is.null(mfx) && !is.null(mfx@draws)) {
             stop_sprintf(
@@ -268,10 +276,23 @@ hypotheses <- function(
         if (...length() > 0) {
             args <- utils::modifyList(args, list(...))
         }
-        se <- do_call(get_se_delta, args)
-        J <- attr(se, "jacobian")
+        J <- hypotheses_exact_jacobian(
+            mfx = mfx,
+            model = model,
+            n_post = length(b),
+            hypothesis_is_formula = hypothesis_is_formula,
+            ...
+        )
+        if (is.null(J)) {
+            se <- do_call(get_se_delta, args)
+            J <- attr(se, "jacobian")
+            attr(se, "jacobian") <- NULL
+        } else {
+            propagated <- std_error_from_jacobian(J, vcov, model, ...)
+            se <- propagated$std.error
+            J <- propagated$jacobian
+        }
         mfx@jacobian <- J
-        attr(se, "jacobian") <- NULL
         mfx@draws <- NULL
 
         # no standard error
@@ -332,4 +353,85 @@ hypotheses <- function(
     attr(out, "hypotheses_call") <- TRUE
 
     return(out)
+}
+
+
+# Post-hoc `hypotheses()` differentiates the composition of two maps: the
+# parameters to the estimates the hypothesis reads, and the hypothesis itself.
+# Finite-differencing the composition is wrong whenever the hypothesis is
+# affine with a large constant, because the probe subtracts two nearly equal
+# large numbers and reports a standard error of exactly zero. An affine
+# hypothesis has an exact contrast matrix whose constant has zero derivative,
+# so the first map is differentiated alone and pulled back through the compiled
+# stage.
+#
+# Returns NULL -- differentiate the whole map numerically, exactly as before --
+# whenever anything cannot be proven eligible.
+hypotheses_exact_jacobian <- function(mfx, model, n_post, hypothesis_is_formula, ...) {
+    hypothesis <- mfx@hypothesis
+    if (isTRUE(hypothesis_is_formula) || !isTRUE(checkmate::check_character(hypothesis))) {
+        return(NULL)
+    }
+    if (!isTRUE(getOption("marginaleffects_hypothesis_promote", default = TRUE))) {
+        return(NULL)
+    }
+    # A user-supplied jacobian function receives the `hypothesis` argument, so
+    # its result already covers the hypothesis stage and must not be composed
+    # with it a second time.
+    if (!is.null(settings_get("jacobian_function"))) {
+        return(NULL)
+    }
+
+    skeleton <- tryCatch(
+        get_hypotheses_skeleton(
+            model_perturbed = model,
+            hypothesis = hypothesis,
+            hypothesis_is_formula = FALSE,
+            ...
+        ),
+        error = function(e) NULL
+    )
+    if (!inherits(skeleton, "data.frame") || !is.numeric(skeleton[["estimate"]])) {
+        return(NULL)
+    }
+    skeleton <- data.table::copy(skeleton)
+
+    compiled <- tryCatch(
+        hypothesis_compile_string(hypothesis, skeleton),
+        error = function(e) NULL
+    )
+    if (is.null(compiled) || !hypothesis_stage_exact(compiled$hyp, n_post = n_post)) {
+        return(NULL)
+    }
+
+    # The derivative of the pre-hypothesis estimates with respect to the
+    # parameters. Those estimates are the object's own estimates or the model
+    # parameters, depending on the input kind, and involve no hypothesis
+    # constant, so numerical differentiation is safe here.
+    jac <- tryCatch(
+        get_delta_jacobian(
+            model_perturbed = model,
+            FUN = get_hypotheses,
+            mfx = mfx,
+            hypothesis = NULL,
+            hypothesis_is_formula = FALSE,
+            ...
+        ),
+        error = function(e) NULL
+    )
+    if (is.null(jac) || !identical(jac$method, "numeric")) {
+        return(NULL)
+    }
+    J <- jac$jacobian
+    if (!isTRUE(checkmate::check_matrix(J, mode = "numeric")) || nrow(J) != nrow(skeleton)) {
+        return(NULL)
+    }
+
+    pulled <- hypothesis_stage_pullback(compiled$hyp, J)
+    if (is.null(pulled) || !isTRUE(nrow(pulled$jacobian) == n_post)) {
+        return(NULL)
+    }
+    out <- pulled$jacobian
+    colnames(out) <- colnames(J)
+    out
 }

--- a/r/R/hypotheses_joint.R
+++ b/r/R/hypotheses_joint.R
@@ -5,10 +5,25 @@ joint_test <- function(
     joint_test = "f",
     df = NULL,
     vcov = TRUE) {
+    vcov <- sanitize_vcov_request(vcov)
     checkmate::assert_choice(joint_test, c("f", "chisq"))
 
     # do not use components() because this may be a model object
     mfx <- attr(object, "marginaleffects")
+    internal_classes <- c("predictions", "comparisons", "slopes", "hypotheses")
+
+    if (inherits(object, internal_classes) && !isTRUE(vcov)) {
+        msg <- paste0(
+            "The `vcov` argument is not available when `object` is a ",
+            "`predictions`, `comparisons`, `slopes`, or `hypotheses` object. ",
+            "Please specify the type of standard errors in the initial ",
+            "`marginaleffects` call."
+        )
+        stop_sprintf(msg)
+    }
+    if (inherits(vcov, "marginaleffects_vcov_unconditional")) {
+        stop_unconditional("hypotheses")
+    }
 
     # Create mfx object if it doesn't exist (needed for joint tests on model objects)
     if (is.null(mfx) && !inherits(object, c("slopes", "comparisons", "predictions", "hypotheses"))) {
@@ -57,6 +72,16 @@ joint_test <- function(
 
     # V_hat: estimated covariance matrix
     V_hat <- get_vcov(object, vcov = vcov)
+    # For marginaleffects objects V_hat is J V J' with rows in estimate order
+    # by construction; for raw models both come from the same coefficient
+    # vector. A dimension mismatch means neither invariant holds.
+    if (!isTRUE(nrow(V_hat) == length(theta_hat))) {
+        stop_sprintf(
+            "The covariance matrix (%s rows) does not match the parameter vector (%s).",
+            nrow(V_hat),
+            length(theta_hat)
+        )
+    }
 
     # R: Q x P matrix for testing Q hypotheses on P parameters
     # build R matrix based on joint_index
@@ -65,7 +90,17 @@ joint_test <- function(
         if (is.numeric(joint_index)) {
             R[i, joint_index[i]] <- 1
         } else {
-            R[i, which(names(theta_hat) == joint_index[i])] <- 1
+            idx <- which(names(theta_hat) == joint_index[i])
+            # A duplicated name would put two 1s in this row and silently test
+            # the sum of both parameters instead of the one the user named.
+            if (length(idx) != 1L) {
+                stop_sprintf(
+                    "The name \"%s\" matches %s estimates. Joint tests need each selected name to identify exactly one estimate; use numeric indices instead.",
+                    joint_index[i],
+                    length(idx)
+                )
+            }
+            R[i, idx] <- 1
         }
     }
 

--- a/r/R/hypothesis_compile.R
+++ b/r/R/hypothesis_compile.R
@@ -1,3 +1,233 @@
+# Extract the coefficient vector of a strictly linear hypothesis expression,
+# by structural recursion on its syntax tree.
+#
+# This is a proof, not a probe: a parse tree built only from estimate
+# references, numeric constants, sums and differences, products with a
+# constant side, and division by a constant denotes a linear map as a matter
+# of syntax, wherever it is evaluated. Anything else -- unknown symbols,
+# function calls, a product of two estimate terms -- yields NULL. No finite
+# set of numeric evaluations can establish this property for arbitrary code,
+# because a function can be built to agree with any fixed evaluation points
+# and disagree elsewhere; the syntactic argument has no such gap. And the
+# same structural walk which proves the map linear also reads off its
+# coefficients, so the contrast matrix comes from the proof itself rather
+# than from re-evaluating the closure against basis vectors.
+#
+# Returns a list with a `coef` vector of length `n_estimates` aligned to
+# estimate positions and the additive `const`, or NULL when the expression is
+# not a valid combination. An affine map is promoted as a matrix plus an
+# offset: the estimates are crossprod(H, x) + offset, and the derivative is
+# H alone, independent of the constant. Differentiating the constant
+# numerically instead is catastrophic -- a large offset cancels the probe
+# step and reports a zero standard error with full confidence.
+#
+# `labels` and `idx` are parallel: `labels[k]` is the symbol which stands for
+# estimate position `idx[k]`.
+hypothesis_expression_coefficients <- function(expr, labels, idx, n_estimates) {
+    position <- stats::setNames(as.integer(idx), labels)
+
+    const_value <- function(e) {
+        v <- tryCatch(eval(e, baseenv()), error = function(err) NULL)
+        if (is.numeric(v) && length(v) == 1L && is.finite(v)) {
+            return(v)
+        }
+        NULL
+    }
+
+    walk <- function(e) {
+        if (is.numeric(e) && length(e) == 1L && is.finite(e)) {
+            return(list(const = as.numeric(e), coef = numeric(n_estimates)))
+        }
+        if (is.symbol(e)) {
+            pos <- position[[as.character(e)]]
+            if (is.null(pos) || is.na(pos)) {
+                return(NULL)
+            }
+            coef <- numeric(n_estimates)
+            coef[pos] <- 1
+            return(list(const = 0, coef = coef))
+        }
+        if (!is.call(e) || length(e) < 2L || !is.symbol(e[[1L]])) {
+            return(NULL)
+        }
+        op <- as.character(e[[1L]])
+        if (op == "(" && length(e) == 2L) {
+            return(walk(e[[2L]]))
+        }
+        if (op %in% c("+", "-") && length(e) == 2L) {
+            a <- walk(e[[2L]])
+            if (is.null(a)) {
+                return(NULL)
+            }
+            if (op == "-") {
+                a$const <- -a$const
+                a$coef <- -a$coef
+            }
+            return(a)
+        }
+        if (op %in% c("+", "-") && length(e) == 3L) {
+            a <- walk(e[[2L]])
+            b <- walk(e[[3L]])
+            if (is.null(a) || is.null(b)) {
+                return(NULL)
+            }
+            s <- if (op == "+") 1 else -1
+            return(list(
+                const = a$const + s * b$const,
+                coef = a$coef + s * b$coef
+            ))
+        }
+        if (op == "*" && length(e) == 3L) {
+            a <- walk(e[[2L]])
+            b <- walk(e[[3L]])
+            if (is.null(a) || is.null(b)) {
+                return(NULL)
+            }
+            a_const <- all(a$coef == 0)
+            b_const <- all(b$coef == 0)
+            if (a_const && b_const) {
+                return(list(const = a$const * b$const, coef = a$coef))
+            }
+            if (a_const) {
+                return(list(const = a$const * b$const, coef = a$const * b$coef))
+            }
+            if (b_const) {
+                return(list(const = a$const * b$const, coef = b$const * a$coef))
+            }
+            return(NULL)
+        }
+        if (op == "/" && length(e) == 3L) {
+            a <- walk(e[[2L]])
+            b <- walk(e[[3L]])
+            if (is.null(a) || is.null(b) || !all(b$coef == 0) || b$const == 0) {
+                return(NULL)
+            }
+            return(list(const = a$const / b$const, coef = a$coef / b$const))
+        }
+        if (op == "^" && length(e) == 3L) {
+            a <- walk(e[[2L]])
+            b <- walk(e[[3L]])
+            if (
+                is.null(a) || is.null(b) ||
+                    !all(a$coef == 0) || !all(b$coef == 0)
+            ) {
+                return(NULL)
+            }
+            v <- a$const^b$const
+            if (!is.finite(v)) {
+                return(NULL)
+            }
+            return(list(const = v, coef = a$coef))
+        }
+        NULL
+    }
+
+    exprs <- as.list(expr)
+    if (length(exprs) != 1L) {
+        return(NULL)
+    }
+    e <- exprs[[1L]]
+    # Top-level "lhs = rhs" is the null-hypothesis form: the closure
+    # computing the estimates evaluates "lhs - (rhs)", so a constant rhs
+    # folds into the affine constant.
+    rhs <- 0
+    if (
+        is.call(e) && length(e) == 3L && is.symbol(e[[1L]]) &&
+            identical(as.character(e[[1L]]), "=")
+    ) {
+        rhs <- const_value(e[[3L]])
+        if (is.null(rhs)) {
+            return(NULL)
+        }
+        e <- e[[2L]]
+    }
+    out <- walk(e)
+    if (is.null(out) || !all(is.finite(out$coef)) || !is.finite(out$const)) {
+        return(NULL)
+    }
+    out$const <- out$const - rhs
+    if (!is.finite(out$const)) {
+        return(NULL)
+    }
+    out
+}
+
+
+# A hypothesis expressed as a string is very often a linear map of the
+# estimates, even when it is stored as an opaque closure. A linear map has an
+# exact matrix representation, which is faster than any probe, exact rather
+# than approximate, and consumable by the analytic Jacobian. Record the
+# hypothesis as a matrix stage when the syntax tree proves linearity; leave
+# the closure in place so estimates are computed exactly as before, and keep
+# every other list element and attribute untouched.
+#
+# `H` is the matrix compiled directly from the syntax tree by the caller: the
+# same walk which proves the map linear also reads off its coefficients, so
+# no basis-vector probing of the closure is involved. User-supplied function
+# hypotheses and formula closures never reach here -- probing cannot prove
+# linearity of arbitrary code, so they stay on the composed-derivative path,
+# which differentiates them at the estimate instead of extrapolating a
+# structure they were never proven to have. The only runtime check retained
+# is one matrix-vector product confirming that H reproduces the estimates the
+# closure computed, which guards the compiler itself.
+# One matrix-vector product confirming that crossprod(H, estimate) + offset
+# reproduces the estimates some closure computed. This is the runtime guard
+# shared by every promotion of a syntactically compiled hypothesis matrix.
+hypothesis_matrix_reproduces <- function(H, estimate, expected, offset = 0) {
+    if (
+        !is.numeric(estimate) || !is.numeric(expected) ||
+            nrow(H) != length(estimate) || ncol(H) != length(expected) ||
+            anyNA(expected) ||
+            !is.numeric(offset) || anyNA(offset) ||
+            !length(offset) %in% c(1L, length(expected))
+    ) {
+        return(FALSE)
+    }
+    want <- tryCatch(
+        as.vector(Matrix::crossprod(H, estimate)) + offset,
+        error = function(e) NULL
+    )
+    if (!is.numeric(want) || length(want) != length(expected) || anyNA(want)) {
+        return(FALSE)
+    }
+    max(abs(want - expected)) <= 1e-9 * max(1, max(abs(expected)))
+}
+
+
+hypothesis_promote_matrix <- function(hyp, cmp_skeleton, H = NULL, offset = 0) {
+    if (is.null(H)) {
+        return(hyp)
+    }
+    if (!isTRUE(getOption("marginaleffects_hypothesis_promote", default = TRUE))) {
+        return(hyp)
+    }
+    if (is.null(hyp) || identical(hyp$kind, "matrix") || !is.function(hyp$apply)) {
+        return(hyp)
+    }
+    estimate <- cmp_skeleton[["estimate"]]
+    if (!is.numeric(estimate) || nrow(H) != length(estimate)) {
+        return(hyp)
+    }
+    base <- tryCatch(hyp$apply(estimate), error = function(e) NULL)
+    if (!hypothesis_matrix_reproduces(H, estimate, base, offset = offset)) {
+        return(hyp)
+    }
+    out <- hyp
+    out$kind <- "matrix"
+    out$H <- H
+    # The estimates are crossprod(H, x) + offset; the derivative is H alone.
+    # Recording the offset keeps validation exact for affine hypotheses such
+    # as "b1 - 5 = 0" without ever differentiating through the constant.
+    out$offset <- offset
+    # Copy attributes individually: replacing the attribute list wholesale
+    # would restore the old `names` and lose the new element.
+    for (nm in setdiff(names(attributes(hyp)), "names")) {
+        attr(out, nm) <- attr(hyp, nm)
+    }
+    out
+}
+
+
 hypothesis_compile <- function(hypothesis, cmp_skeleton, by = NULL, newdata = NULL, mfx = NULL) {
     if (is.null(hypothesis)) {
         return(list(cmp = cmp_skeleton, hyp = NULL))
@@ -51,6 +281,8 @@ hypothesis_compile_wrapper <- function(hypothesis, cmp_skeleton, by, newdata, mf
         apply = function(est) apply_df(est)[["estimate"]]
     )
     attr(hyp, "hypothesis_function_by") <- attr(cmp, "hypothesis_function_by")
+    # Never promoted: the wrapper wraps arbitrary user code, whose linearity
+    # cannot be proven.
     list(cmp = cmp, hyp = hyp)
 }
 
@@ -108,15 +340,151 @@ hypothesis_compile_formula <- function(hypothesis, cmp_skeleton, by, newdata, mf
     }
 
     H <- hypothesis_compile_formula_matrix(form, groups)
-    if (!is.null(H) && ncol(H) == nrow(cmp)) {
+    # Promote only after the runtime check the string path also performs: one
+    # matrix-vector product confirming H reproduces the estimates the closure
+    # computed. Without it, a wrong shortcut block would surface downstream as
+    # an internal replay error instead of degrading to the closure path.
+    if (
+        !is.null(H) && ncol(H) == nrow(cmp) &&
+            hypothesis_matrix_reproduces(H, cmp_skeleton[["estimate"]], cmp[["estimate"]])
+    ) {
         apply <- function(est) as.vector(Matrix::crossprod(H, est))
         hyp <- list(kind = "matrix", apply = apply, H = H)
     } else {
+        # Not promoted to a matrix: either the shortcut's operator is dense
+        # (the centering shortcuts, which get a structured pullback instead)
+        # or whatever reaches this branch -- a ratio shortcut, an
+        # arbitrary-function right-hand side -- has no proven linear
+        # structure.
         hyp <- list(kind = "formula", apply = apply)
+        if (
+            isTRUE(getOption("marginaleffects_hypothesis_promote", default = TRUE)) &&
+                isTRUE(form$lhs %in% c("difference", "dotproduct"))
+        ) {
+            hyp$pullback <- hypothesis_formula_pullback(form$rhs, groups)
+        }
     }
     attr(hyp, "hypothesis_function_by") <- attr(cmp, "hypothesis_function_by")
     list(cmp = cmp, hyp = hyp)
 }
+
+# Exact Jacobian pullback for the centering shortcuts, without materializing
+# their operators. meandev is x - mean(x): its matrix is I - 11'/n, dense in
+# every entry, so t(H) %*% J is computed structurally as J minus the
+# broadcast column means, group by group. meanotherdev is
+# (n/(n-1)) x - sum(x)/(n-1), handled the same way. Both operators are
+# symmetric, so the pullback applies H itself.
+#
+# Returns NULL when the shortcut has no structured pullback or a group is
+# too small for it, which leaves the hypothesis on the probe path.
+hypothesis_formula_pullback <- function(shortcut, groups) {
+    if (!shortcut %in% c("meandev", "meanotherdev")) {
+        return(NULL)
+    }
+    if (identical(shortcut, "meanotherdev") && any(lengths(groups) < 2L)) {
+        return(NULL)
+    }
+    force(groups)
+    function(J) {
+        J <- as.matrix(J)
+        out <- vector("list", length(groups))
+        for (k in seq_along(groups)) {
+            idx <- groups[[k]]
+            B <- J[idx, , drop = FALSE]
+            n <- nrow(B)
+            if (identical(shortcut, "meandev")) {
+                out[[k]] <- B - matrix(colMeans(B), n, ncol(B), byrow = TRUE)
+            } else {
+                out[[k]] <- (n / (n - 1)) * B -
+                    matrix(colSums(B) / (n - 1), n, ncol(B), byrow = TRUE)
+            }
+        }
+        do.call(rbind, out)
+    }
+}
+
+
+# A compiled stage carries an exact derivative when it has a finite contrast
+# matrix of the right width or a structured pullback. Callers which must decide
+# whether to recover the pre-hypothesis estimates -- an expensive replay, and
+# useless when nothing will probe them -- ask this before the Jacobian exists.
+hypothesis_stage_exact <- function(hyp, n_post = NULL) {
+    if (is.null(hyp)) {
+        return(FALSE)
+    }
+    if (identical(hyp$kind, "matrix") && !is.null(hyp$H)) {
+        H <- as.matrix(hyp$H)
+        if (
+            isTRUE(checkmate::check_matrix(H, mode = "numeric")) &&
+                all(is.finite(H)) &&
+                (is.null(n_post) || ncol(H) == n_post)
+        ) {
+            return(TRUE)
+        }
+    }
+    is.function(hyp$pullback)
+}
+
+
+# Pull a Jacobian back through a compiled hypothesis stage. `J` has one row per
+# pre-hypothesis estimate and the result has one row per post-hypothesis
+# estimate. `at` is the pre-hypothesis estimate vector, consulted only when the
+# stage has to be probed numerically. Returns NULL when the stage cannot be
+# differentiated here: the contract is fail-closed, so callers fall back to
+# differentiating the whole pipeline rather than compose something wrong.
+hypothesis_stage_pullback <- function(hyp, J, at = NULL) {
+    if (is.null(hyp)) {
+        return(NULL)
+    }
+
+    # Affine hypotheses map estimates with crossprod(H, estimate) + offset, so H
+    # maps every coefficient column of the Jacobian at once; the offset has zero
+    # derivative and never enters. Probing it numerically instead cancels
+    # catastrophically once the constant is large relative to the estimates.
+    if (identical(hyp$kind, "matrix") && !is.null(hyp$H)) {
+        H <- as.matrix(hyp$H)
+        if (
+            nrow(H) == nrow(J) &&
+                isTRUE(checkmate::check_matrix(H, mode = "numeric")) &&
+                all(is.finite(H))
+        ) {
+            out <- tryCatch(
+                as.matrix(Matrix::crossprod(hyp$H, J)),
+                error = function(e) NULL
+            )
+            if (!isTRUE(checkmate::check_matrix(out, mode = "numeric"))) {
+                return(NULL)
+            }
+            return(list(jacobian = out, exact = TRUE))
+        }
+    }
+
+    # Centering shortcuts carry a structured pullback: their operators are dense
+    # as matrices, and the pullback applies t(H) in O(np) instead. It is exact,
+    # so no numeric-stage provenance attaches.
+    if (is.function(hyp$pullback)) {
+        out <- tryCatch(as.matrix(hyp$pullback(J)), error = function(e) NULL)
+        if (!isTRUE(checkmate::check_matrix(out, mode = "numeric"))) {
+            return(NULL)
+        }
+        return(list(jacobian = out, exact = TRUE))
+    }
+
+    # A hypothesis which is not linear, or whose linearity could not be proved,
+    # is still only a map from a handful of estimates to a handful of tested
+    # quantities. Differentiating that map costs nothing next to a model
+    # evaluation, so the exact Jacobian of everything upstream is composed with
+    # a probe of the hypothesis rather than being discarded.
+    if (!is.function(hyp$apply) || !is.numeric(at) || length(at) != nrow(J)) {
+        return(NULL)
+    }
+    G <- stage_jacobian_dense(hyp$apply, at)
+    if (is.null(G) || ncol(G) != nrow(J)) {
+        return(NULL)
+    }
+    list(jacobian = as.matrix(G %*% J), exact = FALSE)
+}
+
 
 hypothesis_compile_formula_matrix <- function(form, groups) {
     if (!isTRUE(form$lhs %in% c("difference", "dotproduct"))) {
@@ -194,19 +562,10 @@ hypothesis_compile_formula_matrix_block <- function(shortcut, n) {
         ))
     }
 
-    if (shortcut == "meandev") {
-        H <- diag(n) - matrix(1 / n, nrow = n, ncol = n)
-        return(Matrix::Matrix(H, sparse = TRUE))
-    }
-
-    if (shortcut == "meanotherdev") {
-        if (n < 2L) {
-            return(NULL)
-        }
-        H <- diag(n) - matrix(1 / (n - 1L), nrow = n, ncol = n)
-        diag(H) <- 1
-        return(Matrix::Matrix(H, sparse = TRUE))
-    }
+    # meandev and meanotherdev are handled by hypothesis_formula_pullback():
+    # their operators are dense -- every entry of the n x n matrix is nonzero
+    # -- so materializing them costs O(n^2) memory for what is a rank-one
+    # update applied in O(np).
 
     if (shortcut == "poly") {
         H <- stats::contr.poly(n)
@@ -277,5 +636,27 @@ hypothesis_compile_string <- function(hypothesis, cmp_skeleton) {
     }
 
     hyp <- list(kind = "string", apply = apply)
+    # Promotion requires a syntactic proof of shape for every compiled
+    # expression, never a numeric probe: the walk which proves the map affine
+    # also compiles the contrast matrix column by column, and reads off the
+    # additive constant. Any expression outside the affine fragment (a
+    # product of estimates, a function call) yields NULL and leaves the
+    # hypothesis as a closure.
+    n_estimates <- nrow(cmp_skeleton)
+    columns <- lapply(compiled, function(cc) {
+        hypothesis_expression_coefficients(
+            cc$expr,
+            cc$labels,
+            cc$idx,
+            n_estimates
+        )
+    })
+    H <- NULL
+    offset <- 0
+    if (length(columns) > 0L && !any(vapply(columns, is.null, logical(1)))) {
+        H <- do.call(cbind, lapply(columns, `[[`, "coef"))
+        offset <- vapply(columns, `[[`, numeric(1), "const")
+    }
+    hyp <- hypothesis_promote_matrix(hyp, cmp_skeleton, H = H, offset = offset)
     list(cmp = cmp, hyp = hyp)
 }

--- a/r/R/inferences.R
+++ b/r/R/inferences.R
@@ -205,6 +205,9 @@ inferences <- function(
     # Issue #1501: `newdata` should only use the pre-evaluated `newdata` instead of bootstrapping datagrid()
     mfx <- attr(x, "marginaleffects")
     call_mfx <- mfx@call
+    if (isTRUE(grepl("^Unconditional", mfx@vcov_type))) {
+        stop_unconditional("inferences")
+    }
 
     # Update call with pre-evaluated newdata if available
     if (!is.null(call_mfx)) {

--- a/r/R/inferences_simulation.R
+++ b/r/R/inferences_simulation.R
@@ -154,14 +154,46 @@ inferences_simulation <- function(x, R = 1000, conf_level = 0.95, conf_type = "p
         cols <- setdiff(names(out), c("p.value", "std.error", "statistic", "s.value", "df"))
     } else if (conf_type == "wald") {
         alpha <- 1 - conf_level
-        out$statistic <- out$estimate / out$std.error
+
+        # The user's null and direction travel with the object. Testing
+        # against zero, two-sided, would answer a different question than the
+        # one the user asked with `hypothesis = "... = 1"` or a one-sided
+        # `equivalence`-style direction.
+        hypothesis_null <- mfx@hypothesis_null
+        if (!isTRUE(checkmate::check_number(hypothesis_null))) {
+            hypothesis_null <- 0
+        }
+        hypothesis_direction <- mfx@hypothesis_direction
+        if (
+            !isTRUE(checkmate::check_character(hypothesis_direction, min.len = 1))
+        ) {
+            hypothesis_direction <- "="
+        }
+
+        out$statistic <- (out$estimate - hypothesis_null) / out$std.error
 
         critical <- abs(stats::qnorm(alpha / 2))
 
         out$conf.low <- out$estimate - critical * out$std.error
         out$conf.high <- out$estimate + critical * out$std.error
 
+        if (!length(hypothesis_direction) %in% c(1L, nrow(out))) {
+            stop_sprintf(
+                "Length of hypothesis_direction (%s) must equal number of rows (%s)",
+                length(hypothesis_direction),
+                nrow(out)
+            )
+        }
+        direction <- rep_len(hypothesis_direction, nrow(out))
         out$p.value <- 2 * stats::pnorm(-abs(out$statistic))
+        idx <- direction == "<="
+        if (any(idx)) {
+            out$p.value[idx] <- 1 - stats::pnorm(out$statistic[idx])
+        }
+        idx <- direction == ">="
+        if (any(idx)) {
+            out$p.value[idx] <- stats::pnorm(out$statistic[idx])
+        }
         out$s.value <- -log2(out$p.value)
 
         cols <- setdiff(names(out), "df")

--- a/r/R/jacobian_stage.R
+++ b/r/R/jacobian_stage.R
@@ -1,0 +1,111 @@
+# Stage-by-stage Jacobian composition.
+#
+# Every estimand marginaleffects computes is a pipeline:
+#
+#   beta -> eta = X beta -> predictions -> comparison -> aggregation -> hypothesis
+#
+# The Jacobian of the pipeline is the product of the stage Jacobians. The
+# expensive link is the first one, because it is the only stage which touches
+# the model and the full data. Every later stage is cheap arithmetic on numbers
+# which have already been computed.
+#
+# Differentiating the whole composition at once forces one model evaluation per
+# coefficient, and it also destroys accuracy: a stage which averages n
+# predictions carries roundoff of order n * .Machine$double.eps, and dividing
+# that by a coefficient-scaled finite-difference step amplifies it by many
+# orders of magnitude (#1750).
+#
+# Composing instead lets an exact first-stage Jacobian survive a downstream
+# hypothesis stage which happens to be opaque. Such a hypothesis may be
+# differentiated numerically through its own arithmetic, never by re-running
+# the model, and the resulting method is labeled accordingly. Arbitrary custom
+# comparison functions are not probed: without an explicit trusted derivative
+# they fall back to differentiating the full pipeline.
+
+
+# `plan$need_y` is set conservatively: it is TRUE for every custom comparison
+# function, because such a function might accept the observed outcome as an
+# argument. Whether any of them actually does is recorded group by group.
+plan_groups_use_y <- function(plan) {
+    if (!isTRUE(plan$need_y)) {
+        return(FALSE)
+    }
+    if (is.null(plan$groups) || length(plan$groups) == 0L) {
+        return(TRUE)
+    }
+    any(vapply(plan$groups, function(g) isTRUE(g$uses_y), logical(1)))
+}
+
+
+# Central-difference step. Scaled to the value being perturbed so that the step
+# is meaningful for both tiny and large estimates, and eps^(1/3) because that
+# balances truncation against roundoff for a central difference.
+stage_probe_step <- function(x) {
+    pmax(abs(x), 1) * .Machine$double.eps^(1 / 3)
+}
+
+
+# Probing a hypothesis stage column by column costs one call per estimate and
+# each call is itself linear in the number of estimates. That is trivial next
+# to a model evaluation at ordinary sizes and quadratic at extreme ones, so
+# very wide stages keep their previous path.
+stage_probe_max_dim <- function() {
+    getOption("marginaleffects_stage_probe_max_dim", default = 500L)
+}
+
+
+stage_probe_finite <- function(x) {
+    is.numeric(x) && length(x) > 0L && all(is.finite(x))
+}
+
+
+#' Numeric Jacobian of a cheap hypothesis map, by central differences
+#'
+#' Differentiates `f` column by column. This is only used for downstream
+#' hypothesis arithmetic. It is never used to infer that arbitrary comparison
+#' code is analytic or structurally linear.
+#'
+#' @param f function taking a numeric vector and returning a numeric vector
+#' @param x numeric vector, the point at which to differentiate
+#' @param n_out expected length of `f(x)`, or NULL to infer
+#' @return a `n_out x length(x)` matrix, or NULL when the probe is unusable
+#' @keywords internal
+#' @noRd
+stage_jacobian_dense <- function(f, x, n_out = NULL) {
+    if (!stage_probe_finite(x)) {
+        return(NULL)
+    }
+    if (length(x) > stage_probe_max_dim()) {
+        return(NULL)
+    }
+    base <- tryCatch(f(x), error = function(e) NULL)
+    if (!stage_probe_finite(base)) {
+        return(NULL)
+    }
+    if (is.null(n_out)) {
+        n_out <- length(base)
+    } else if (length(base) != n_out) {
+        return(NULL)
+    }
+
+    step <- stage_probe_step(x)
+    out <- matrix(NA_real_, nrow = n_out, ncol = length(x))
+    for (j in seq_along(x)) {
+        hi <- lo <- x
+        hi[j] <- hi[j] + step[j]
+        lo[j] <- lo[j] - step[j]
+        fhi <- tryCatch(f(hi), error = function(e) NULL)
+        flo <- tryCatch(f(lo), error = function(e) NULL)
+        if (
+            !stage_probe_finite(fhi) || !stage_probe_finite(flo) ||
+                length(fhi) != n_out || length(flo) != n_out
+        ) {
+            return(NULL)
+        }
+        out[, j] <- (fhi - flo) / (2 * step[j])
+    }
+    if (!all(is.finite(out))) {
+        return(NULL)
+    }
+    out
+}

--- a/r/R/methods_MASS.R
+++ b/r/R/methods_MASS.R
@@ -129,21 +129,8 @@ get_model_matrix.negbin <- function(model, newdata, mfx = NULL) {
 
 #' @noRd
 #' @export
-get_jacobian_analytic.negbin <- function(model, type, ...) {
-    if (
-        !identical(class(model)[1], "negbin") ||
-            !isTRUE(type %in% c("response", "link"))
-    ) {
-        return(NULL)
-    }
-    response_scale <- identical(type, "response")
-    jacobian_analytic_model_matrix(
-        model = model,
-        type = type,
-        response_scale = response_scale,
-        family = if (response_scale) stats::family(model) else NULL,
-        ...
-    )
+get_prediction_jacobian_spec.negbin <- function(model, type, ...) {
+    prediction_jacobian_spec_glm_family(model, "negbin", type)
 }
 
 
@@ -156,17 +143,6 @@ get_model_matrix.rlm <- function(model, newdata, mfx = NULL) {
 
 #' @noRd
 #' @export
-get_jacobian_analytic.rlm <- function(model, type, ...) {
-    if (
-        !identical(class(model)[1], "rlm") ||
-            !identical(type, "response")
-    ) {
-        return(NULL)
-    }
-    jacobian_analytic_model_matrix(
-        model = model,
-        type = type,
-        response_scale = FALSE,
-        ...
-    )
+get_prediction_jacobian_spec.rlm <- function(model, type, ...) {
+    prediction_jacobian_spec_linear(model, "rlm", type, "response")
 }

--- a/r/R/methods_aaa.R
+++ b/r/R/methods_aaa.R
@@ -31,13 +31,24 @@ get_predict.lm <- function(
     MM <- attr(newdata, "marginaleffects_model_matrix")
     beta <- get_coef(model)
     if (!isTRUE(checkmate::check_matrix(MM)) || ncol(MM) != length(beta)) {
-        out <- get_predict.default(
-            model = model,
-            newdata = newdata,
-            type = type,
-            ...
+        out <- tryCatch(
+            get_predict.default(
+                model = model,
+                newdata = newdata,
+                type = type,
+                ...
+            ),
+            error = function(e) e
         )
-        return(out)
+        if (!inherits(out, "error")) {
+            return(out)
+        }
+        # `stats::predict()` failed. Linear predictions only need the model
+        # matrix and the coefficients, so retry that way. This rescues fit
+        # objects stripped of components that `predict()` requires, such as
+        # `qr$qr` deleted to save memory.
+        newdata <- model_matrix_retry(model, newdata, beta, out)
+        MM <- attr(newdata, "marginaleffects_model_matrix")
     }
     p <- model$rank
     p1 <- seq_len(p)
@@ -72,23 +83,43 @@ get_predict.glm <- function(
     type = "response",
     ...) {
     out <- NULL
+    link <- isTRUE(checkmate::check_choice(type, "link"))
+    response <- isTRUE(checkmate::check_choice(type, "response")) || is.null(type)
     MM <- attr(newdata, "marginaleffects_model_matrix")
-    if (isTRUE(checkmate::check_matrix(MM))) {
-        if (isTRUE(checkmate::check_choice(type, c("link")))) {
-            out <- get_predict.lm(model = model, newdata = newdata, ...)
-        } else if (isTRUE(checkmate::check_choice(type, "response")) || is.null(type)) {
-            out <- get_predict.lm(model = model, newdata = newdata, ...)
+    if (isTRUE(checkmate::check_matrix(MM)) && (link || response)) {
+        out <- get_predict.lm(model = model, newdata = newdata, ...)
+        if (response) {
             out$estimate <- stats::family(model)$linkinv(out$estimate)
         }
     }
 
     if (is.null(out)) {
-        out <- get_predict.default(
-            model = model,
-            newdata = newdata,
-            type = type,
-            ...
+        out <- tryCatch(
+            get_predict.default(
+                model = model,
+                newdata = newdata,
+                type = type,
+                ...
+            ),
+            error = function(e) e
         )
+        if (inherits(out, "error")) {
+            # See the comment in `get_predict.lm()`: retry through the model
+            # matrix, which only makes sense on the link and response scales.
+            if (!link && !response) {
+                stop(out)
+            }
+            newdata <- model_matrix_retry(
+                model,
+                newdata,
+                get_coef(model),
+                out
+            )
+            out <- get_predict.lm(model = model, newdata = newdata, ...)
+            if (response) {
+                out$estimate <- stats::family(model)$linkinv(out$estimate)
+            }
+        }
     }
 
     return(out)
@@ -110,85 +141,4 @@ set_coef.nls <- function(model, coefs, ...) {
 #' @export
 get_coef.nls <- function(model, ...) {
     model$m$getPars()
-}
-
-
-#' @keywords internal
-#' @export
-get_autodiff_args.lm <- function(model, mfx, type) {
-    # no inheritance! Important to avoid breaking other models
-    if (!class(model)[1] %in% c("lm", "ivreg")) {
-        return(NULL)
-    }
-
-    if (!is.null(model$offset)) {
-        return("models with offsets")
-    }
-
-    if ("weights" %in% names(model$call)) {
-        return("models with weights")
-    }
-
-    # Check type support
-    if (!type %in% c("response", "link", "invlink(link)")) {
-        return(sprintf("`type='%s'`", type))
-    }
-
-    # If all checks pass, return supported arguments
-    out <- list(model_type = "linear", family = NULL, link = NULL)
-    return(out)
-}
-
-
-#' @keywords internal
-#' @export
-get_autodiff_args.glm <- function(model, mfx, type) {
-    # no inheritance! Important to avoid breaking other models
-    if (!class(model)[1] == "glm") {
-        return(NULL)
-    }
-
-    if (!is.null(model$offset)) {
-        return("models with offsets")
-    }
-
-    if ("weights" %in% names(model$call)) {
-        return("models with weights")
-    }
-
-    # Check type support
-    if (!type %in% c("response", "link", "invlink(link)")) {
-        return(sprintf("`type='%s'`", type))
-    }
-
-    if (type %in% c("link", "invlink(link)")) {
-        return(list(model_type = "linear", family = NULL, link = NULL))
-    }
-
-    # For GLM, check if family/link combination is supported
-    family_name <- model$family$family
-    link_name <- model$family$link
-
-    supported_families <- c("gaussian", "binomial", "poisson", "Gamma")
-    if (!family_name %in% supported_families) {
-        return("unsupported GLM family/link combinations")
-    }
-
-    supported_links <- list(
-        gaussian = c("identity", "log", "inverse"),
-        binomial = c("logit", "probit", "cloglog", "log"),
-        poisson = c("log", "identity", "sqrt"),
-        Gamma = c("inverse", "identity", "log")
-    )
-    if (!link_name %in% supported_links[[family_name]]) {
-        return("unsupported GLM family/link combinations")
-    }
-
-    # If all checks pass, return supported arguments
-    out <- list(
-        model_type = "glm",
-        family = family_name,
-        link = link_name
-    )
-    return(out)
 }

--- a/r/R/methods_betareg.R
+++ b/r/R/methods_betareg.R
@@ -40,7 +40,14 @@ get_coef.betareg <- function(model, ...) {
     out <- model$coefficients
     for (n in names(out)) {
         if (n %in% c("phi", "precision")) {
-            names(out[[n]]) <- sprintf("(phi)_%s", names(out[[n]]))
+            # With no precision formula betareg already names the single
+            # precision coefficient "(phi)". Prefixing that again yields
+            # "(phi)_(phi)", which stops matching get_vcov() and makes a
+            # user-supplied vcov matrix impossible to name correctly.
+            nms <- names(out[[n]])
+            prefix <- nms != "(phi)"
+            nms[prefix] <- sprintf("(phi)_%s", nms[prefix])
+            names(out[[n]]) <- nms
         }
     }
     out <- stats::setNames(unlist(out), unlist(lapply(out, names)))

--- a/r/R/methods_brglm2.R
+++ b/r/R/methods_brglm2.R
@@ -39,19 +39,6 @@ get_model_matrix.brglmFit <- function(model, newdata, mfx = NULL) {
 
 #' @noRd
 #' @export
-get_jacobian_analytic.brglmFit <- function(model, type, ...) {
-    if (
-        !identical(class(model)[1], "brglmFit") ||
-            !isTRUE(type %in% c("response", "link"))
-    ) {
-        return(NULL)
-    }
-    response_scale <- identical(type, "response")
-    jacobian_analytic_model_matrix(
-        model = model,
-        type = type,
-        response_scale = response_scale,
-        family = if (response_scale) stats::family(model) else NULL,
-        ...
-    )
+get_prediction_jacobian_spec.brglmFit <- function(model, type, ...) {
+    prediction_jacobian_spec_glm_family(model, "brglmFit", type)
 }

--- a/r/R/methods_geepack.R
+++ b/r/R/methods_geepack.R
@@ -9,19 +9,6 @@ get_model_matrix.geeglm <- function(model, newdata, mfx = NULL) {
 
 #' @noRd
 #' @export
-get_jacobian_analytic.geeglm <- function(model, type, ...) {
-    if (
-        !identical(class(model)[1], "geeglm") ||
-            !isTRUE(type %in% c("response", "link"))
-    ) {
-        return(NULL)
-    }
-    response_scale <- identical(type, "response")
-    jacobian_analytic_model_matrix(
-        model = model,
-        type = type,
-        response_scale = response_scale,
-        family = if (response_scale) stats::family(model) else NULL,
-        ...
-    )
+get_prediction_jacobian_spec.geeglm <- function(model, type, ...) {
+    prediction_jacobian_spec_glm_family(model, "geeglm", type)
 }

--- a/r/R/methods_ivreg.R
+++ b/r/R/methods_ivreg.R
@@ -1,8 +1,3 @@
-#' @keywords internal
-#' @export
-get_autodiff_args.ivreg <- get_autodiff_args.lm
-
-
 #' @rdname get_model_matrix
 #' @export
 get_model_matrix.ivreg <- function(model, newdata, mfx = NULL) {
@@ -28,17 +23,6 @@ get_model_matrix.ivreg <- function(model, newdata, mfx = NULL) {
 
 #' @noRd
 #' @export
-get_jacobian_analytic.ivreg <- function(model, type, ...) {
-    if (
-        !identical(class(model)[1], "ivreg") ||
-            !identical(type, "response")
-    ) {
-        return(NULL)
-    }
-    jacobian_analytic_model_matrix(
-        model = model,
-        type = type,
-        response_scale = FALSE,
-        ...
-    )
+get_prediction_jacobian_spec.ivreg <- function(model, type, ...) {
+    prediction_jacobian_spec_linear(model, "ivreg", type, "response")
 }

--- a/r/R/methods_quantreg.R
+++ b/r/R/methods_quantreg.R
@@ -61,17 +61,6 @@ get_model_matrix.rq <- function(model, newdata, mfx = NULL) {
 
 #' @noRd
 #' @export
-get_jacobian_analytic.rq <- function(model, type, ...) {
-    if (
-        !identical(class(model)[1], "rq") ||
-            !identical(type, "response")
-    ) {
-        return(NULL)
-    }
-    jacobian_analytic_model_matrix(
-        model = model,
-        type = type,
-        response_scale = FALSE,
-        ...
-    )
+get_prediction_jacobian_spec.rq <- function(model, type, ...) {
+    prediction_jacobian_spec_linear(model, "rq", type, "response")
 }

--- a/r/R/methods_rms.R
+++ b/r/R/methods_rms.R
@@ -124,114 +124,28 @@ get_model_matrix.lrm <- get_model_matrix.ols
 
 #' @noRd
 #' @export
-get_jacobian_analytic.ols <- function(model, type, ...) {
-    if (
-        !identical(class(model)[1], "ols") ||
-            !identical(type, "lp")
-    ) {
-        return(NULL)
-    }
-    jacobian_analytic_model_matrix(
-        model = model,
-        type = type,
-        response_scale = FALSE,
-        ...
-    )
+get_prediction_jacobian_spec.ols <- function(model, type, ...) {
+    prediction_jacobian_spec_linear(model, "ols", type, "lp")
 }
 
 
 #' @noRd
 #' @export
-get_jacobian_analytic.lrm <- function(model, type, ...) {
+get_prediction_jacobian_spec.lrm <- function(model, type, ...) {
+    # The fitted scale is a plain logit only for a binary outcome with no
+    # special link functions; ordinal or custom-family fits stay numeric.
     if (
-        !identical(class(model)[1], "lrm") ||
-            !isTRUE(type %in% c("lp", "fitted"))
-    ) {
-        return(NULL)
-    }
-
-    response_scale <- identical(type, "fitted")
-    if (
-        response_scale &&
+        identical(type, "fitted") &&
             (!identical(model$non.slopes, 1L) || length(model$famfunctions) > 0L)
     ) {
         return(NULL)
     }
-    jacobian_analytic_model_matrix(
-        model = model,
-        type = type,
-        response_scale = response_scale,
-        family = if (response_scale) stats::binomial("logit") else NULL,
-        ...
+    prediction_jacobian_spec_glm_family(
+        model,
+        "lrm",
+        type,
+        response_type = "fitted",
+        link_type = "lp",
+        family = stats::binomial("logit")
     )
 }
-
-
-
-### AUTODIFF: 
-### The analytic path above uses predictrms(type = "x"). Keep the old JAX
-### sketches below disabled unless they can use that same RMS-native matrix.
-
-# #' @keywords internal
-# #' @export
-# get_autodiff_args.ols <- function(model, mfx) {
-#     # no inheritance! Important to avoid breaking other models
-#     if (!class(model)[1] == "ols") {
-#         return(NULL)
-#     }
-#
-#     if (!is.null(model$offset)) {
-#         autodiff_warning("models with offsets")
-#         return(NULL)
-#     }
-#
-#     if (!is.null(model$penalty)) {
-#         autodiff_warning("models with offsets")
-#         return(NULL)
-#     }
-#
-#     # Check type support
-#     if (!mfx@type %in% c("lp")) {
-#         autodiff_warning(sprintf("`type='%s'`", mfx@type))
-#         return(NULL)
-#     }
-#
-#     # If all checks pass, return supported arguments
-#     out <- list(model_type = "linear")
-#     return(out)
-# }
-#
-#
-# #' @keywords internal
-# #' @export
-# get_autodiff_args.lrm <- function(model, mfx) {
-#     # no inheritance! Important to avoid breaking other models
-#     if (!class(model)[1] == "lrm") {
-#         return(NULL)
-#     }
-#
-#     if (!is.null(model$offset)) {
-#         autodiff_warning("models with offsets")
-#         return(NULL)
-#     }
-#
-#     if (!is.null(model$penalty)) {
-#         autodiff_warning("models with offsets")
-#         return(NULL)
-#     }
-#
-#     # Check type support
-#     if (!mfx@type %in% c("fitted", "lp")) {
-#         autodiff_warning(sprintf("`type='%s'`", mfx@type))
-#         return(NULL)
-#     }
-#
-#     # If all checks pass, return supported arguments
-#     mAD <- settings_get("mAD")
-#     out <- list(
-#         model_type = "glm",
-#         family_type = mAD$glm$families$Family$BINOMIAL,
-#         link_type = mAD$glm$families$Link$LOGIT
-#     )
-#     return(out)
-# }

--- a/r/R/methods_stats.R
+++ b/r/R/methods_stats.R
@@ -23,37 +23,13 @@ get_model_matrix.glm <- get_model_matrix.lm
 
 #' @noRd
 #' @export
-get_jacobian_analytic.lm <- function(model, type, ...) {
-    if (
-        !identical(class(model)[1], "lm") ||
-            !isTRUE(type %in% c("response", "link"))
-    ) {
-        return(NULL)
-    }
-    jacobian_analytic_model_matrix(
-        model = model,
-        type = type,
-        response_scale = FALSE,
-        ...
-    )
+get_prediction_jacobian_spec.lm <- function(model, type, ...) {
+    prediction_jacobian_spec_linear(model, "lm", type, c("response", "link"))
 }
 
 
 #' @noRd
 #' @export
-get_jacobian_analytic.glm <- function(model, type, ...) {
-    if (
-        !identical(class(model)[1], "glm") ||
-            !isTRUE(type %in% c("response", "link"))
-    ) {
-        return(NULL)
-    }
-    response_scale <- identical(type, "response")
-    jacobian_analytic_model_matrix(
-        model = model,
-        type = type,
-        response_scale = response_scale,
-        family = if (response_scale) stats::family(model) else NULL,
-        ...
-    )
+get_prediction_jacobian_spec.glm <- function(model, type, ...) {
+    prediction_jacobian_spec_glm_family(model, "glm", type)
 }

--- a/r/R/methods_survey.R
+++ b/r/R/methods_survey.R
@@ -119,21 +119,8 @@ get_model_matrix.svyglm <- function(model, newdata, mfx = NULL) {
 
 #' @noRd
 #' @export
-get_jacobian_analytic.svyglm <- function(model, type, ...) {
-    if (
-        !identical(class(model)[1], "svyglm") ||
-            !isTRUE(type %in% c("response", "link"))
-    ) {
-        return(NULL)
-    }
-    response_scale <- identical(type, "response")
-    jacobian_analytic_model_matrix(
-        model = model,
-        type = type,
-        response_scale = response_scale,
-        family = if (response_scale) stats::family(model) else NULL,
-        ...
-    )
+get_prediction_jacobian_spec.svyglm <- function(model, type, ...) {
+    prediction_jacobian_spec_glm_family(model, "svyglm", type)
 }
 
 

--- a/r/R/package.R
+++ b/r/R/package.R
@@ -59,7 +59,6 @@ utils::globalVariables(c(
     "lo",
     "logLik",
     "m",
-    "mAD",
     "marginaleffects_contrast_hi",
     "marginaleffects_contrast_lo",
     "marginaleffects_formula_idx",

--- a/r/R/plan_replay.R
+++ b/r/R/plan_replay.R
@@ -30,11 +30,12 @@ record_plan_aggregation <- function(
         return(list(out = estimates, agg = NULL))
     }
 
-    missing <- setdiff(setdiff(colnames(by), "by"), colnames(estimates))
-    needs_source_id <- length(missing) > 0 || isTRUE(checkmate::check_data_frame(by))
+    # Only a `by` data frame can reorder or drop rows on its way through the
+    # resolver's merges and joins; explicit source ids keep the replay
+    # indices anchored to the original estimate positions in that case.
+    needs_source_id <- isTRUE(checkmate::check_data_frame(by))
     if (isTRUE(needs_source_id)) {
         estimates <- data.table::copy(estimates)
-        # Needed when joins or filters can change row positions.
         plan_id <- ".marginaleffects_plan_est_id"
         while (plan_id %in% colnames(estimates)) {
             plan_id <- paste0(".", plan_id)
@@ -43,39 +44,10 @@ record_plan_aggregation <- function(
     }
     estimate_source <- estimates[["estimate"]]
 
-    if (length(missing) > 0) {
-        # Bring grouping columns back before computing aggregation groups.
-        estimates <- merge_original_data(
-            estimates,
-            newdata,
-            keys = c("rowid", "rowidcf"),
-            payload = missing,
-            unit_level_only = FALSE
-        )
-    }
+    resolved <- resolve_by_rows(estimates, newdata, by, verbose = verbose)
+    estimates <- resolved$estimates
+    bycols <- resolved$bycols
 
-    if (isTRUE(by)) {
-        regex <- "^term$|^group$|^contrast$|^contrast_"
-        bycols <- grep(regex, colnames(estimates), value = TRUE)
-    } else if (isTRUE(checkmate::check_character(by))) {
-        bycols <- by
-    } else if (isTRUE(checkmate::check_data_frame(by))) {
-        idx <- setdiff(intersect(colnames(estimates), colnames(by)), "by")
-        by <- harmonize_by_types(estimates, by)
-        estimates[by, by := by, on = idx]
-        bycols <- "by"
-    }
-
-    if ("by" %in% colnames(estimates) && anyNA(estimates[["by"]])) {
-        # User-supplied by data can intentionally cover only some rows.
-        msg <- insight::format_message(
-            "The `by` data.frame does not cover all combinations of response levels and/or predictors. Some estimates will not be included in the aggregation."
-        )
-        if (isTRUE(verbose)) warning(msg, call. = FALSE)
-        estimates <- estimates[!is.na(by), drop = FALSE]
-    }
-
-    bycols <- intersect(unique(c("term", bycols)), colnames(estimates))
     weighted <- "marginaleffects_wts_internal" %in% colnames(newdata)
 
     # Record replay indices with the same groups as the displayed aggregate.
@@ -145,21 +117,61 @@ apply_plan_aggregation <- function(agg, est) {
     out
 }
 
-apply_plan_aggregation_and_hypothesis <- function(est, agg = NULL, hyp = NULL) {
-    # Preserve original pipeline order: aggregate, then transform/test.
+apply_plan_stages <- function(est, agg = NULL, hyp = NULL) {
+    # Preserve original pipeline order: aggregate, then transform/test. The
+    # intermediate value is returned as well because the hypothesis stage is
+    # differentiated at the estimates which feed it, not at its own output.
     if (!is.null(agg)) {
         est <- apply_plan_aggregation(agg, est)
     }
+    pre <- est
     if (!is.null(hyp)) {
         est <- hyp$apply(est)
     }
-    est
+    list(pre = pre, post = est)
 }
+
+# Element-wise agreement for replay guards. all.equal() compares a *mean*
+# relative difference, under which one badly wrong row hides inside enough
+# correct ones; a guard advertised as fail-closed must bound every element.
+#
+# Missing values are legitimate on some model paths (tidymodels predictions,
+# for one), so a missing entry is agreement exactly when it is missing on
+# both sides -- the same convention all.equal() applies. A value present on
+# one side and missing on the other is disagreement.
+plan_replay_agrees <- function(a, b, tolerance = sqrt(.Machine$double.eps)) {
+    if (length(a) != length(b)) {
+        return(FALSE)
+    }
+    if (!is.numeric(a) || !is.numeric(b)) {
+        # Classification models predict factors or characters. There is no
+        # tolerance question for those: agreement is exact equality, which
+        # all.equal() checks element by element for non-numeric types.
+        return(isTRUE(all.equal(a, b, check.attributes = FALSE)))
+    }
+    finite_a <- is.finite(a)
+    finite_b <- is.finite(b)
+    if (!identical(finite_a, finite_b)) {
+        return(FALSE)
+    }
+    # Non-finite entries are compared exactly rather than by subtraction: Inf
+    # minus Inf is NaN, which would read as disagreement and raise the generic
+    # "plan baseline check failed" error on top of whatever the caller was
+    # about to report. A user-supplied `comparison` function returning Inf is a
+    # user error with its own message, not a stale replay plan.
+    if (!identical(a[!finite_a], b[!finite_b])) {
+        return(FALSE)
+    }
+    a <- a[finite_a]
+    b <- b[finite_b]
+    delta <- abs(a - b)
+    isTRUE(all(delta <= tolerance * pmax(abs(b), 1)))
+}
+
 
 validate_plan_replay <- function(kind, baseline, expected) {
     # Guard against stale or incomplete replay plans.
-    tolerance <- sqrt(.Machine$double.eps)
-    if (!isTRUE(all.equal(baseline, expected, tolerance = tolerance, check.attributes = FALSE))) {
+    if (!plan_replay_agrees(baseline, expected)) {
         stop_sprintf("Internal error: %s plan baseline check failed.", kind)
     }
 }
@@ -234,18 +246,214 @@ simulation_replay_validate <- function(replay, model, expected) {
         simulation_replay_evaluate(replay, model),
         error = function(e) NULL
     )
-    if (
-        length(baseline) != length(expected) ||
-            !isTRUE(all.equal(
-                baseline,
-                expected,
-                tolerance = sqrt(.Machine$double.eps),
-                check.attributes = FALSE
-            ))
-    ) {
+    # Element-wise, like every other replay gate: a mean-relative check would
+    # let one badly wrong row hide among enough correct ones.
+    if (!plan_replay_agrees(baseline, expected)) {
         return(NULL)
     }
     replay
+}
+
+
+# Wrap a candidate Jacobian in the resolver's return shape. `propagate` is the
+# caller's covariance propagation, which doubles as a validity check: a
+# derivative whose covariance cannot be formed is not usable, so the candidate
+# is refused and the caller falls back to the next one. `safe` distinguishes a
+# candidate with a fallback behind it from the last resort, whose errors belong
+# to the user.
+plan_jacobian_result <- function(J, method, propagate, safe = TRUE) {
+    if (is.null(propagate)) {
+        return(list(jacobian = J, method = method))
+    }
+    propagated <- if (isTRUE(safe)) {
+        tryCatch(propagate(J), error = function(e) NULL)
+    } else {
+        propagate(J)
+    }
+    if (is.null(propagated)) {
+        return(NULL)
+    }
+    list(
+        jacobian = propagated$jacobian,
+        method = method,
+        std.error = propagated$std.error
+    )
+}
+
+
+# Differentiate a recorded plan with respect to the model coefficients. This is
+# the single entry point for every consumer of a plan Jacobian, so the routing
+# between the user's own derivative, the analytic derivative, and numerical
+# differentiation is decided in one place.
+#
+# `propagate` is an optional function of the candidate Jacobian which returns
+# the propagated `list(std.error, jacobian)`, or NULL when the candidate cannot
+# be propagated; callers which want a Jacobian and nothing else omit it and
+# never form a covariance matrix. Returns NULL when no derivative is available
+# -- posterior draws, for one -- and otherwise a list with `jacobian` (one row
+# per estimate), `method` ("custom", "analytic", "analytic+numeric_stage", or
+# "numeric"), and `std.error` when `propagate` was supplied.
+compute_plan_jacobian <- function(
+    plan,
+    mfx,
+    estimates,
+    type,
+    kind,
+    dots = list(),
+    contrast_data = NULL,
+    variables = NULL,
+    numderiv = NULL,
+    analytic = TRUE,
+    propagate = NULL) {
+    # Explicit user Jacobians retain priority. Everything else prefers the
+    # analytic derivative, which is on by default, and falls back to numerical
+    # differentiation when the estimand is not eligible for it.
+    custom_jacobian <- settings_get("jacobian_function")
+
+    analytic_enabled <- isTRUE(analytic) &&
+        isTRUE(getOption("marginaleffects_analytic_jacobian", default = TRUE))
+    if (is.null(custom_jacobian) && analytic_enabled) {
+        J <- get_jacobian_analytic(
+            model = mfx@model,
+            plan = plan,
+            kind = kind,
+            type = type,
+            estimate = estimates[["estimate"]],
+            contrast_data = contrast_data
+        )
+        if (!is.null(J)) {
+            method <- if (isTRUE(attr(
+                J,
+                "marginaleffects_numeric_stage",
+                exact = TRUE
+            ))) {
+                "analytic+numeric_stage"
+            } else {
+                "analytic"
+            }
+            out <- plan_jacobian_result(J, method, propagate)
+            if (!is.null(out)) {
+                return(out)
+            }
+        }
+    }
+
+    # Numerical differentiation, stopping before the hypothesis stage whenever
+    # that stage can be differentiated on its own. Differentiating the whole
+    # composition forces the finite difference to see an average over many
+    # predictions, whose roundoff is then amplified by the inverse of the
+    # coefficient-scaled step; composing instead keeps the model evaluations on
+    # the well-scaled quantity and reuses the Jacobian rather than discarding
+    # it (#1750).
+    numeric_jacobian <- function(compose) {
+        if (identical(kind, "predictions")) {
+            # Delta method callback: predict, then replay prediction plan.
+            fun <- function(model_perturbed, ...) {
+                pred <- prediction_plan_predict(plan, model_perturbed, ...)
+                stages <- prediction_plan_apply_stages(plan, pred)
+                if (isTRUE(compose)) stages$pre else stages$post
+            }
+            args <- list(
+                mfx = mfx,
+                model_perturbed = mfx@model,
+                type = type,
+                FUN = fun,
+                hypothesis = if (isTRUE(compose)) NULL else mfx@hypothesis
+            )
+        } else {
+            # Delta method callback: predict hi/lo, then replay comparison plan.
+            fun <- function(model_perturbed, ...) {
+                preds <- comparison_plan_predict(plan, model_perturbed, ...)
+                stages <- comparison_plan_apply_stages(
+                    plan,
+                    preds$hi,
+                    preds$lo,
+                    preds$or
+                )
+                if (isTRUE(compose)) stages$pre else stages$post
+            }
+            args <- list(
+                mfx = mfx,
+                model_perturbed = mfx@model,
+                type = type,
+                FUN = fun,
+                variables = variables,
+                hypothesis = if (isTRUE(compose)) NULL else mfx@hypothesis,
+                hi = contrast_data$hi,
+                lo = contrast_data$lo,
+                original = contrast_data$original,
+                estimates = estimates,
+                numderiv = numderiv
+            )
+        }
+        args <- utils::modifyList(args, dots)
+        do_call(get_delta_jacobian, args)
+    }
+
+    hyp <- plan$hyp
+    # `stage_pull` maps the pre-hypothesis Jacobian to the post-hypothesis
+    # one. Exact when the stage has a compiled matrix (an affine map's
+    # derivative does not depend on its offset -- probing the offset
+    # numerically cancels catastrophically) or a structured pullback (the
+    # centering shortcuts, whose operators are dense as matrices); a
+    # central-difference probe of the stage arithmetic otherwise.
+    stage_pull <- NULL
+    # A user-supplied Jacobian function is authoritative and already covers the
+    # whole pipeline, hypothesis included, so it is never composed with.
+    if (!is.null(hyp) && is.null(custom_jacobian)) {
+        exact <- hypothesis_stage_exact(hyp, n_post = nrow(estimates))
+        # Recovering the pre-hypothesis estimates replays the plan, so it is
+        # only worth doing when the probe is the sole remaining option.
+        estimate_pre <- if (exact) {
+            NULL
+        } else {
+            plan_replay_estimate_pre(
+                plan = plan,
+                kind = kind,
+                estimate = estimates[["estimate"]]
+            )
+        }
+        if (exact || !is.null(estimate_pre)) {
+            stage_pull <- function(J) {
+                res <- hypothesis_stage_pullback(hyp, J, at = estimate_pre)
+                if (is.null(res)) NULL else res$jacobian
+            }
+        }
+    }
+
+    jac <- numeric_jacobian(!is.null(stage_pull))
+    if (is.null(jac)) {
+        return(NULL)
+    }
+
+    if (!is.null(stage_pull)) {
+        # A dimension mismatch errors inside the pull and lands here as NULL,
+        # which the fail-closed branch below turns into a redo.
+        composed <- tryCatch(
+            as.matrix(stage_pull(jac$jacobian)),
+            error = function(e) NULL
+        )
+        if (!is.null(composed) && nrow(composed) == nrow(estimates)) {
+            # The inner derivative's provenance survives the composition: the
+            # pull only rescales the stage a custom or numeric J produced.
+            out <- plan_jacobian_result(composed, jac$method, propagate)
+            if (!is.null(out)) {
+                return(out)
+            }
+        }
+        # Fail closed. A partially composed result would be silently wrong, so
+        # an unusable composition redoes the original whole-pipeline
+        # derivative. The repeat is inherent, not an optimization miss: the
+        # fallback differentiates through the hypothesis stage by re-running
+        # the model, which the pre-hypothesis Jacobian computed above cannot
+        # supply once the pull is unusable.
+        jac <- numeric_jacobian(FALSE)
+        if (is.null(jac)) {
+            return(NULL)
+        }
+    }
+
+    plan_jacobian_result(jac$jacobian, jac$method, propagate, safe = FALSE)
 }
 
 
@@ -254,10 +462,25 @@ plan_std_error <- function(
     mfx,
     estimates,
     type,
+    vcov = NULL,
     dots = list(),
     contrast_data = NULL,
     variables = NULL,
     numderiv = NULL) {
+    if (inherits(vcov, "marginaleffects_vcov_unconditional")) {
+        return(plan_unconditional_se(
+            built = built,
+            mfx = mfx,
+            estimates = estimates,
+            type = type,
+            dots = dots,
+            contrast_data = contrast_data,
+            variables = variables,
+            numderiv = numderiv,
+            unconditional = vcov
+        ))
+    }
+
     if ("std.error" %in% colnames(estimates) ||
         (!is.null(mfx) && !is.null(mfx@draws))) {
         return(list(mfx = mfx, estimates = estimates))
@@ -274,100 +497,92 @@ plan_std_error <- function(
         return(list(mfx = mfx, estimates = estimates))
     }
 
-    # Explicit user Jacobians retain priority. Otherwise, use a validated exact
-    # analytic derivative before trying autodiff and numerical differentiation.
-    custom_jacobian <- settings_get("jacobian_function")
-    analytic_enabled <- isTRUE(getOption(
-        "marginaleffects_analytic_jacobian",
-        default = TRUE
-    ))
-    if (is.null(custom_jacobian) && analytic_enabled) {
-        J <- get_jacobian_analytic(
-            model = mfx@model,
-            plan = plan,
-            kind = kind,
-            type = type,
-            estimate = estimates[["estimate"]],
-            contrast_data = contrast_data
-        )
-        if (!is.null(J)) {
-            propagated <- tryCatch(
-                std_error_from_jacobian(J, mfx@vcov_model, mfx@model),
-                error = function(e) NULL
-            )
-            if (!is.null(propagated)) {
-                mfx@jacobian <- propagated$jacobian
-                estimates[["std.error"]] <- propagated$std.error
-                return(list(mfx = mfx, estimates = estimates))
-            }
-        }
-    }
-
-    # Try autodiff next; fall back to numerical delta method.
-    ad_args <- list(
+    jac <- compute_plan_jacobian(
         plan = plan,
         mfx = mfx,
-        kind = kind,
+        estimates = estimates,
         type = type,
-        vcov = mfx@vcov_model,
-        estimate = estimates[["estimate"]]
+        kind = kind,
+        dots = dots,
+        contrast_data = contrast_data,
+        variables = variables,
+        numderiv = numderiv,
+        propagate = function(J) {
+            # Model-specific arguments which no formal upstream absorbed must
+            # reach get_coef() during vcov alignment: gamlss models, for one,
+            # cannot extract coefficients without their `what` argument.
+            extra <- dots[setdiff(
+                names(dots),
+                c("", names(formals(get_delta_jacobian)))
+            )]
+            do_call(
+                std_error_from_jacobian,
+                c(list(J, mfx@vcov_model, mfx@model), extra)
+            )
+        }
     )
-    if (identical(kind, "comparisons")) {
-        ad_args$hi <- contrast_data$hi
-        ad_args$lo <- contrast_data$lo
-    }
-    ad <- if (is.null(custom_jacobian)) do_call(autodiff_try, ad_args) else NULL
-    if (!is.null(ad)) {
-        mfx@jacobian <- ad$jacobian
-        estimates[["std.error"]] <- ad$std.error
-        return(list(mfx = mfx, estimates = estimates))
+    se <- jac$std.error
+
+    # Provenance records what actually produced the stored matrix, not which
+    # options were set: a custom jacobian function which returned NULL fell
+    # back to numerical differentiation and must say so.
+    mfx@jacobian_method <- jac$method %||% "numeric"
+
+    # A custom Jacobian is honored, not silently recycled or dropped: if its
+    # row count does not match the estimates it claims to differentiate, the
+    # standard errors it implies are meaningless.
+    if (
+        identical(mfx@jacobian_method, "custom") &&
+            (!is.numeric(se) || length(se) != nrow(estimates))
+    ) {
+        stop_sprintf(
+            "The matrix returned by the `marginaleffects_jacobian_function` option has %s row(s), but there are %s estimates.",
+            length(se),
+            nrow(estimates)
+        )
     }
 
-    if (identical(kind, "predictions")) {
-        # Delta method callback: predict, then replay prediction plan.
-        fun <- function(model_perturbed, ...) {
-            pred <- prediction_plan_predict(plan, model_perturbed, ...)
-            prediction_plan_apply(plan, pred)
-        }
-        args <- list(
-            mfx = mfx,
-            model_perturbed = mfx@model,
-            vcov = mfx@vcov_model,
-            type = type,
-            FUN = fun,
-            hypothesis = mfx@hypothesis
-        )
-        args <- utils::modifyList(args, dots)
-        se <- do_call(get_se_delta, args)
-        if (is.numeric(se) && length(se) == nrow(estimates)) {
-            mfx@jacobian <- attr(se, "jacobian")
-            estimates[["std.error"]] <- as.vector(se)
-        }
-    } else {
-        # Delta method callback: predict hi/lo, then replay comparison plan.
-        fun <- function(model_perturbed, ...) {
-            preds <- comparison_plan_predict(plan, model_perturbed, ...)
-            comparison_plan_apply(plan, preds$hi, preds$lo, preds$or)
-        }
-        args <- list(
-            mfx = mfx,
-            model_perturbed = mfx@model,
-            vcov = mfx@vcov_model,
-            type = type,
-            FUN = fun,
-            variables = variables,
-            hypothesis = mfx@hypothesis,
-            hi = contrast_data$hi,
-            lo = contrast_data$lo,
-            original = contrast_data$original,
-            estimates = estimates,
-            numderiv = numderiv
-        )
-        args <- utils::modifyList(args, dots)
-        se <- do_call(get_se_delta, args)
-        mfx@jacobian <- attr(se, "jacobian")
-        estimates[["std.error"]] <- as.vector(as.numeric(se))
+    # Same guard for both kinds: an SE vector whose length does not match the
+    # estimates must not be assigned, because data.table recycling would
+    # silently repeat a scalar across every row.
+    if (is.numeric(se) && length(se) == nrow(estimates)) {
+        mfx@jacobian <- jac$jacobian
+        estimates[["std.error"]] <- as.vector(se)
     }
 
     list(mfx = mfx, estimates = estimates)
+}
+
+
+# Recover the estimates which feed the hypothesis stage, using the predictions
+# recorded when the plan was built. Fails closed: the recovered stage output
+# must reproduce the reported estimates, otherwise the plan is stale or the
+# pipeline needs a model evaluation this shortcut cannot supply.
+plan_replay_estimate_pre <- function(plan, kind, estimate) {
+    if (plan_groups_use_y(plan)) {
+        return(NULL)
+    }
+    stages <- tryCatch(
+        {
+            if (identical(kind, "predictions")) {
+                prediction_plan_apply_stages(plan, plan$baseline_prediction)
+            } else {
+                comparison_plan_apply_stages(
+                    plan,
+                    plan$baseline_hi,
+                    plan$baseline_lo
+                )
+            }
+        },
+        error = function(e) NULL
+    )
+    if (is.null(stages) || !is.numeric(stages$pre)) {
+        return(NULL)
+    }
+    # Element-wise, like every other replay gate: a mean-relative check would
+    # let one badly wrong row hide among enough correct ones.
+    if (!plan_replay_agrees(stages$post, estimate)) {
+        return(NULL)
+    }
+    stages$pre
 }

--- a/r/R/plot_comparisons.R
+++ b/r/R/plot_comparisons.R
@@ -60,6 +60,7 @@ plot_comparisons <- function(
     gray = getOption("marginaleffects_plot_gray", default = FALSE),
     draw = TRUE,
     ...) {
+    vcov <- sanitize_vcov_request(vcov)
     if (inherits(model, c("mira", "amest"))) {
         msg <- "This function does not support multiple imputation. Call `comparisons()` or `avg_comparisons()` instead. These functions return easy to plot data frames."
         stop_sprintf(msg)

--- a/r/R/plot_predictions.R
+++ b/r/R/plot_predictions.R
@@ -69,6 +69,7 @@ plot_predictions <- function(
   draw = TRUE,
   ...
 ) {
+    vcov <- sanitize_vcov_request(vcov)
     checkmate::assert_number(points, lower = 0, upper = 1)
 
     if (inherits(model, c("mira", "amest"))) {

--- a/r/R/plot_slopes.R
+++ b/r/R/plot_slopes.R
@@ -67,6 +67,7 @@ plot_slopes <- function(
     gray = getOption("marginaleffects_plot_gray", default = FALSE),
     draw = TRUE,
     ...) {
+    vcov <- sanitize_vcov_request(vcov)
     if ("effect" %in% ...names()) {
         if (is.null(variables)) {
             variables <- ...elt(match("effect", ...names())[1L])

--- a/r/R/predictions.R
+++ b/r/R/predictions.R
@@ -189,6 +189,8 @@ predictions <- function(
     numderiv = "fdforward",
     ...
 ) {
+    vcov <- sanitize_vcov_request(vcov)
+
     # init
     mfx <- marginaleffects_init(
         model = model,
@@ -205,20 +207,23 @@ predictions <- function(
     scall <- rlang::enquo(newdata)
     mfx <- add_newdata(mfx, scall, newdata = newdata, by = by, wts = wts)
 
-    # inferences() dispatch
-    inferences_dispatch <- sanitize_inferences_method(vcov)
-    vcov <- inferences_dispatch$vcov
-    inferences_method <- inferences_dispatch$method
-
-    dots <- list(...)
-    sanity_dots(model = mfx@model, ...)
-
     # multiple imputation
     if (inherits(mfx@model, c("mira", "amest"))) {
         out <- process_imputation(mfx)
         return(out)
     }
 
+    # inferences() dispatch
+    inferences_dispatch <- sanitize_inferences_method(vcov)
+    vcov <- inferences_dispatch$vcov
+    inferences_method <- inferences_dispatch$method
+    unconditional <- inherits(vcov, "marginaleffects_vcov_unconditional")
+    if (unconditional) {
+        vcov <- sanitize_unconditional_vcov_request(vcov, mfx)
+    }
+
+    dots <- list(...)
+    sanity_dots(model = mfx@model, ...)
 
     # sanity checks
     mfx <- add_numderiv(mfx, numderiv)
@@ -302,23 +307,24 @@ predictions <- function(
     # bayesian posterior draws
     mfx@draws <- attr(tmp, "posterior_draws")
 
-    if (!isFALSE(vcov)) {
+    if (!unconditional && !isFALSE(vcov)) {
         mfx@vcov_type <- get_vcov_label(vcov)
         mfx@vcov_model <- get_vcov(mfx@model, vcov = vcov, type = prediction_type, ...)
     }
 
-    # Delta method for standard errors
     se <- plan_std_error(
         built = built,
         mfx = mfx,
         estimates = tmp,
         type = prediction_type,
-        dots = dots
+        vcov = vcov,
+        dots = dots,
+        variables = mfx@variables
     )
     mfx <- se$mfx
     tmp <- se$estimates
 
-    # Common path for both autodiff and fallback
+    # Common path for both the analytic and fallback paths
 
     mfx <- add_degrees_of_freedom(
         mfx = mfx,
@@ -328,7 +334,11 @@ predictions <- function(
         vcov = vcov,
         newdata = unpadded_newdata
     )
-    if (!is.null(mfx@df) && is.numeric(mfx@df)) {
+    if (unconditional && !unconditional_df_has_finite(mfx@df)) {
+        if ("df" %in% colnames(tmp)) {
+            tmp$df <- NULL
+        }
+    } else if (!is.null(mfx@df) && is.numeric(mfx@df)) {
         tmp$df <- mfx@df
     }
 
@@ -342,6 +352,9 @@ predictions <- function(
     } else {
         NULL
     }
+
+    conf_int <- (!isFALSE(vcov) || unconditional) &&
+        ("std.error" %in% colnames(out) || !is.null(mfx@draws))
 
     capture_replay <- identical(inferences_method, "simulation") ||
         settings_equal("marginaleffects_capture_simulation_replay", TRUE)
@@ -361,7 +374,7 @@ predictions <- function(
         class_name = "predictions",
         inferences_method = inferences_method,
         drop_group = TRUE,
-        conf_int = !isFALSE(vcov) && ("std.error" %in% colnames(out) || !is.null(mfx@draws)),
+        conf_int = conf_int,
         pre_transform = linv,
         ...
     ))
@@ -403,6 +416,9 @@ avg_predictions <- function(
     #Construct predictions() call
     call_attr <- construct_call(model, "predictions")
     call_attr[["by"]] <- by
+    if (missing(df)) {
+        call_attr[["df"]] <- NULL
+    }
 
     out <- eval.parent(call_attr)
 

--- a/r/R/predictions_plan_frequentist.R
+++ b/r/R/predictions_plan_frequentist.R
@@ -52,12 +52,17 @@ prediction_plan_build_frequentist <- function(
 }
 
 
-prediction_plan_apply <- function(plan, pred) {
+prediction_plan_apply_stages <- function(plan, pred) {
     stopifnot(length(pred) == plan$n_pred)
     if (!is.null(plan$keep)) {
         pred <- pred[plan$keep]
     }
-    apply_plan_aggregation_and_hypothesis(pred, plan$agg, plan$hyp)
+    apply_plan_stages(pred, plan$agg, plan$hyp)
+}
+
+
+prediction_plan_apply <- function(plan, pred) {
+    prediction_plan_apply_stages(plan, pred)$post
 }
 
 

--- a/r/R/sanitize_comparison.R
+++ b/r/R/sanitize_comparison.R
@@ -50,6 +50,141 @@ comparison_function_dict <- list(
     "expdydxavgwts" = function(hi, lo, eps, w) wmean(((exp(hi) - exp(lo)) / exp(eps)) / eps, w)
 )
 
+# Exact derivatives of the built-in comparison functions.
+#
+# Every entry mirrors one closed-form definition in
+# `comparison_function_dict` directly above, differentiated by hand with
+# respect to the `hi` and `lo` prediction vectors. The two tables sit in one
+# file so that a shorthand cannot be added or edited here without its
+# derivative in view; R/inst/tinytest/test-comparison-registry.R asserts that
+# they stay in step. Closed forms carry no step size, no structural
+# assumption, and no verification burden: they are correct wherever they are
+# finite, and where they are not finite the caller's finiteness check rejects
+# the group and the estimand falls back to the numeric path.
+#
+# Only recorded built-ins are differentiated. A user-supplied comparison
+# closure is arbitrary code, and no finite set of probe evaluations can prove
+# structural facts about arbitrary code -- a function built to agree with the
+# probes and disagree elsewhere defeats any such scheme. Unknown keys
+# therefore return NULL and keep the whole estimand on the numeric
+# whole-pipeline path.
+#
+# `eyex` and `eydx` never reach this table because their `y` formal marks
+# their groups `uses_y`, which disqualifies the analytic path upstream.
+comparison_gradient_exact <- function(fun_key, hi, lo, args) {
+  n <- length(hi)
+
+  # Normalized averaging weights: NULL for rowwise keys, else a vector
+  # summing to 1 which also encodes plain means.
+  avg <- grepl("avg", fun_key, fixed = TRUE)
+  a <- NULL
+  if (avg) {
+    if (grepl("wts$", fun_key)) {
+      w <- args[["w"]]
+      if (
+        !is.numeric(w) || length(w) != n || any(!is.finite(w)) || sum(w) == 0
+      ) {
+        return(NULL)
+      }
+      a <- w / sum(w)
+    } else {
+      a <- rep.int(1 / n, n)
+    }
+  }
+  wmean_or_mean <- function(x) if (is.null(a)) mean(x) else sum(a * x)
+
+  # Slope-family keys divide by the recorded step; validate it once.
+  eps <- NULL
+  if (fun_key %in% c(
+    "dydx", "dydxavg", "dydxavgwts",
+    "dyex", "dyexavg", "dyexavgwts",
+    "expdydx", "expdydxavg", "expdydxavgwts"
+  )) {
+    eps <- args[["eps"]]
+    if (
+      !is.numeric(eps) || !length(eps) %in% c(1L, n) ||
+        any(!is.finite(eps)) || any(eps == 0)
+    ) {
+      return(NULL)
+    }
+  }
+  x <- args[["x"]]
+
+  switch(fun_key,
+    difference = list(hi = rep.int(1, n), lo = rep.int(-1, n)),
+    differenceavg = ,
+    differenceavgwts = list(hi = a, lo = -a),
+    ratio = ,
+    lift = list(hi = 1 / lo, lo = -hi / lo^2),
+    ratioavg = ,
+    ratioavgwts = ,
+    liftavg = ,
+    liftavgwts = {
+      # liftavg = wmean(hi - lo) / wmean(lo) = wmean(hi) / wmean(lo) - 1,
+      # so its gradient is the gradient of ratioavg.
+      mh <- wmean_or_mean(hi)
+      ml <- wmean_or_mean(lo)
+      list(hi = a / ml, lo = -a * mh / ml^2)
+    },
+    lnratio = list(hi = 1 / hi, lo = -1 / lo),
+    lnratioavg = ,
+    lnratioavgwts = {
+      mh <- wmean_or_mean(hi)
+      ml <- wmean_or_mean(lo)
+      list(hi = a / mh, lo = -a / ml)
+    },
+    lnor = list(
+      hi = 1 / (hi * (1 - hi)),
+      lo = -1 / (lo * (1 - lo))
+    ),
+    lnoravg = ,
+    lnoravgwts = {
+      mh <- wmean_or_mean(hi)
+      ml <- wmean_or_mean(lo)
+      list(hi = a / (mh * (1 - mh)), lo = -a / (ml * (1 - ml)))
+    },
+    dydx = list(hi = rep_len(1 / eps, n), lo = rep_len(-1 / eps, n)),
+    dydxavg = ,
+    dydxavgwts = list(hi = a / eps, lo = -a / eps),
+    dyex = {
+      if (!is.numeric(x) || !length(x) %in% c(1L, n)) {
+        return(NULL)
+      }
+      list(hi = rep_len(x / eps, n), lo = rep_len(-x / eps, n))
+    },
+    dyexavg = ,
+    dyexavgwts = {
+      if (!is.numeric(x) || !length(x) %in% c(1L, n)) {
+        return(NULL)
+      }
+      list(hi = a * x / eps, lo = -a * x / eps)
+    },
+    expdydx = list(
+      hi = exp(hi) / (exp(eps) * eps),
+      lo = -exp(lo) / (exp(eps) * eps)
+    ),
+    expdydxavg = ,
+    expdydxavgwts = list(
+      hi = a * exp(hi) / (exp(eps) * eps),
+      lo = -a * exp(lo) / (exp(eps) * eps)
+    ),
+    NULL
+  )
+}
+
+
+# Comparison keys the derivative table above is not expected to handle: `eyex`
+# and `eydx` and their averaged variants divide by the observed outcome `y`,
+# which marks their groups `uses_y` and disqualifies the analytic path
+# upstream, so no closed form is recorded for them by design. Kept as data so
+# the registry test can assert the exclusion rather than hardcode it twice.
+comparison_gradient_excluded <- c(
+    "eyex", "eydx",
+    "eyexavg", "eydxavg",
+    "eyexavgwts", "eydxavgwts"
+)
+
+
 comparison_label_dict <- list(
     "difference" = "%s - %s",
     "differenceavg" = "%s - %s",
@@ -80,7 +215,12 @@ comparison_label_dict <- list(
     "lift" = "lift(%s, %s)",
     "liftavg" = "lift(%s, %s)",
     "liftavgwts" = "lift(%s, %s)",
-    "expdydx" = "exp(dY/dX)"
+    # All three must carry the label: get_comparisons_data_numeric() keys the
+    # eps-step derivative contrast off it, and without an entry the averaged
+    # variants silently fell back to the default "+1" unit contrast.
+    "expdydx" = "exp(dY/dX)",
+    "expdydxavg" = "exp(dY/dX)",
+    "expdydxavgwts" = "exp(dY/dX)"
 )
 
 sanity_comparison <- function(comparison) {

--- a/r/R/sanitize_numderiv.R
+++ b/r/R/sanitize_numderiv.R
@@ -17,7 +17,7 @@ add_numderiv <- function(mfx, numderiv) {
                 )
             }
         } else if (numderiv[[1L]] == "richardson") {
-            valid <- c("eps", "d", "zero_tol", "size", "r", "v")
+            valid <- c("eps", "d", "zero_tol", "side", "r", "v")
             if (!all(names(numderiv)[-1L] %in% valid)) {
                 stop(
                     sprintf(

--- a/r/R/sanitize_vcov.R
+++ b/r/R/sanitize_vcov.R
@@ -1,3 +1,42 @@
+# Normalize special user-facing shorthands before model validation and
+# covariance dispatch. Ordinary vcov specifications pass through unchanged.
+
+# `trace()`, `debug()` and coverage instrumentation replace a package function
+# with a wrapper that keeps the original in its `original` slot. Comparing the
+# wrapper with `identical()` fails, so peel the wrappers off both sides first.
+# Test runners which instrument the namespace (scrutin, covr) would otherwise
+# send `vcovUnconditional` down the ordinary estimator path, where it is called
+# with the model as its `type` argument.
+untrace_function <- function(f) {
+    while (inherits(f, "functionWithTrace") && !is.null(attr(f, "original"))) {
+        f <- attr(f, "original")
+    }
+    f
+}
+
+sanitize_vcov_request <- function(vcov) {
+    # Most functions supplied to `vcov` are covariance estimators and are
+    # called with the model later. `vcovUnconditional` is instead a request
+    # constructor, so normalize its bare-function form before generic function
+    # dispatch tries to call it with the model as its `type` argument.
+    if (
+        is.function(vcov) &&
+            identical(untrace_function(vcov), untrace_function(vcovUnconditional))
+    ) {
+        return(vcovUnconditional())
+    }
+    if (
+        is.character(vcov) &&
+            length(vcov) == 1L &&
+            !is.na(vcov) &&
+            identical(tolower(vcov), "unconditional")
+    ) {
+        return(vcovUnconditional())
+    }
+    vcov
+}
+
+
 sanitize_vcov <- function(model, vcov) {
     # TRUE generates a warning in `insight::get_varcov` for some models
     if (isTRUE(checkmate::check_flag(vcov))) {

--- a/r/R/sanity_model.R
+++ b/r/R/sanity_model.R
@@ -172,6 +172,14 @@ sanitize_model <- function(model, call, newdata = NULL, vcov = NULL, by = FALSE,
     # Extract calling_function from mfx@call
     calling_function <- extract_calling_function(call)
 
+    if (
+        inherits(vcov, "marginaleffects_vcov_unconditional") &&
+        !inherits(model, c("mira", "amest"))
+    ) {
+        validate_unconditional_model_support(model, kind = calling_function)
+    }
+
+
     # Sanitize the model
     model <- sanitize_model_specific(
         model,

--- a/r/R/settings.R
+++ b/r/R/settings.R
@@ -2,7 +2,7 @@ marginaleffects_settings <- new.env()
 
 # https://stackoverflow.com/questions/79786610/solved-r-package-loading-error-onattach-failed-in-attachnamespace
 # The disk config is cached in memory: settings_get() is called in hot loops
-# (e.g., once per estimate for "autodiff" and "marginaleffects_safefun_return1"),
+# (e.g., once per estimate for "marginaleffects_safefun_return1"),
 # and reading the filesystem on every miss is expensive.
 settings_read_persistent <- function() {
     cache <- marginaleffects_settings[[".persistent_config_cache"]]

--- a/r/R/slopes.R
+++ b/r/R/slopes.R
@@ -46,6 +46,12 @@
 #'  * String which indicates the kind of uncertainty estimates to return.
 #'    - Heteroskedasticity-consistent: `"HC"`, `"HC0"`, `"HC1"`, `"HC2"`, `"HC3"`, `"HC4"`, `"HC4m"`, `"HC5"`. See `?sandwich::vcovHC`
 #'    - Heteroskedasticity and autocorrelation consistent: `"HAC"`
+#'    - Unconditional: `"unconditional"` accounts for sampling variation in
+#'      the empirical covariate distribution for averaged or aggregated
+#'      predictions, comparisons, and slopes. Hypotheses applied directly to
+#'      unit-level effects are rejected. Use
+#'      `vcovUnconditional(cluster = ~cluster)` for
+#'      one-way clustered unconditional inference.
 #'    - Mixed-Models degrees of freedom: "satterthwaite", "kenward-roger"
 #'    - Other: `"NeweyWest"`, `"KernHAC"`, `"OPG"`. See the `sandwich` package documentation.
 #'    - `"rsample"`, `"boot"`, `"fwb"`, or `"simulation"`: forward the result to `inferences()` using that method.
@@ -242,6 +248,7 @@ slopes <- function(
     eps = NULL,
     numderiv = "fdforward",
     ...) {
+    vcov <- sanitize_vcov_request(vcov)
     call_attr <- construct_call(model, "slopes")
 
     # slopes() does not support a named list of variables like comparisons()
@@ -274,6 +281,9 @@ slopes <- function(
     call_attr_c[["cross"]] <- FALSE
     call_attr_c[["internal_call"]] <- TRUE
     call_attr_c[["slope"]] <- NULL
+    if (missing(df)) {
+        call_attr_c[["df"]] <- NULL
+    }
 
     out <- eval.parent(call_attr_c)
 
@@ -306,6 +316,9 @@ avg_slopes <- function(
     numderiv = "fdforward",
     ...) {
     call_attr <- construct_call(model, "slopes")
+    if (missing(df)) {
+        call_attr[["df"]] <- NULL
+    }
     out <- eval.parent(call_attr)
     return(out)
 }

--- a/r/R/utils.R
+++ b/r/R/utils.R
@@ -71,8 +71,13 @@ finalize_estimates <- function(
 
     out <- sort_columns(out, mfx@newdata, by)
     out <- equivalence(out, equivalence = equivalence, df = mfx@df, draws = mfx@draws, ...)
+    estimate_pre_transform <- out[["estimate"]]
     out <- backtransform(out, transform = pre_transform, draws = mfx@draws)
+    mfx <- update_unconditional_vcov_transform(mfx, estimate_pre_transform, pre_transform)
+
+    estimate_pre_transform <- out[["estimate"]]
     out <- backtransform(out, transform = transform, draws = mfx@draws)
+    mfx <- update_unconditional_vcov_transform(mfx, estimate_pre_transform, transform)
 
     new_draws <- attr(out, "posterior_draws")
     if (!is.null(new_draws)) {

--- a/r/R/vcov_unconditional.R
+++ b/r/R/vcov_unconditional.R
@@ -1,0 +1,968 @@
+# Unconditional variance for averaged predictions and comparisons
+#
+# This file implements influence-function variance estimates that account for
+# two sources of uncertainty: estimation of the model coefficients and sampling
+# variation in the empirical distribution of the covariates over which results
+# are averaged. At a high level, the implementation:
+#
+# 1. records and replays the prediction or comparison plan;
+# 2. differentiates the final estimand with respect to model coefficients;
+# 3. constructs its empirical-distribution influence component for population
+#    or subgroup averages, including supported scalar contrasts;
+# 4. obtains each coefficient's observation-level influence function and
+#    combines the two components after aggregation and hypotheses; and
+# 5. forms a robust or one-way cluster-robust covariance matrix from their sum.
+#
+# `vcovUnconditional()` creates the user-facing variance request. The
+# `plan_unconditional_se()` path coordinates the calculation; the remaining
+# helpers linearize predictions, comparisons, transformations, and model
+# coefficients. Request validation and row-to-model-data matching live in
+# `vcov_unconditional_sanitization.R`.
+
+
+# User-facing request -------------------------------------------------------
+
+#' EXPERIMENTAL: Request unconditional variance in marginaleffects calls
+#'
+#' @param type Character string specifying the finite-sample adjustment. The
+#'   available types are `"HC0"` and `"HC1"`. `"HC0"` uses the raw plug-in
+#'   covariance, while `"HC1"` multiplies the complete unconditional covariance
+#'   by a conventional model degrees-of-freedom factor analogous to the one
+#'   used by the `sandwich` package.
+#' @param cluster An optional one-sided formula such as `~id` identifying the
+#'   variable used for one-way clustered inference. The right-hand side must be
+#'   a bare variable name; transformations and multiple variables are not
+#'   supported. As in the default behavior of [sandwich::vcovCL()], clustered
+#'   estimates include the cluster-count adjustment `G / (G - 1)`.
+#'
+#' @return An object which can be supplied to the `vcov` argument of
+#'   [avg_predictions()], [avg_comparisons()], or [avg_slopes()].
+#'
+#' @details
+#' The bare function form `vcov = vcovUnconditional` is equivalent to
+#' `vcov = vcovUnconditional()`.
+#'
+#' Without clustering, HC0 applies no finite-sample multiplier and HC1 applies
+#' `n / (n - k)`. With clustering, HC0 applies `G / (G - 1)` and HC1 applies
+#' `G / (G - 1) * (n - 1) / (n - k)`, where `k` is the dimension of the model's
+#' estimating-function system and `G` is the number of clusters. These
+#' multipliers match the corresponding `sandwich` adjustments. They are applied
+#' after the coefficient-estimation and empirical-distribution influence
+#' components have been combined. HC1 therefore scales the variance of both
+#' components and their cross-covariance; it does not correct only the
+#' first-stage model-score contribution. HC0 is the plug-in estimator derived by
+#' Hansen and Overgaard. Applying the HC1 multiplier to the complete
+#' unconditional influence function is a documented convention, not a
+#' target-level correction derived in that paper, and it is not generally an
+#' unbiased finite-sample correction. Because its factor depends on `k`, HC1 can
+#' differ across model specifications even when they produce the same averaged
+#' estimand. The `df` argument of the calling
+#' `marginaleffects` function controls the reference distribution for inference
+#' separately and does not determine these covariance multipliers.
+#'
+#' Unconditional variance is available for effects evaluated over original
+#' model-data rows, valid subsets of those rows, or counterfactual grids that
+#' preserve a valid `rowid`/`rowidcf` mapping to original model-data rows. The
+#' effect must be averaged or aggregated with `avg_*()` or `by`, or it must be a
+#' scalar comparison. Hypotheses applied directly to unit-level effects are
+#' rejected because the empirical-distribution influence function is not
+#' identifiable from an arbitrary post-hoc hypothesis function. Synthetic grids
+#' such as `newdata = "mean"` are rejected because the current implementation
+#' cannot generally infer how those grid values vary with the empirical
+#' covariate distribution. Models must provide compatible score and bread
+#' matrices through `sandwich::estfun()`/`sandwich::bread()` or model-specific
+#' equivalents. Supported model classes are validated through an allow-list.
+#' Survey-weighted linear and generalized linear models fitted by
+#' [survey::svyglm()] are supported using their observation-level coefficient
+#' influence functions.
+#' For multiple-imputation objects, unconditional variance is estimated in each
+#' completed dataset and the results are pooled using Rubin's rules. Prediction
+#' methods that return posterior draws, censored and survival models such as
+#' `tobit`, `survreg`, and `coxph`, average
+#' predictions from `fixest` models with fixed effects, and nonlinear `fixest`
+#' models with fixed effects are rejected explicitly. For `feols` models with
+#' fixed effects, unconditional inference is available for additive differences
+#' and `dydx`/`dyex` slopes when the
+#' counterfactual data leave every fixed-effect and varying-slope variable
+#' unchanged. The combined influence function retains the covariance between
+#' coefficient estimation and
+#' the empirical covariate distribution, which is one ingredient of robustness
+#' to conditional-mean misspecification. That robustness also requires the
+#' model's score and bread methods to represent the derivative of its full
+#' estimating equations; this is not guaranteed for every supported model and
+#' link under misspecification. HC2 through HC5 are not available because their
+#' regression-leverage adjustments are not defined for this combined influence
+#' function.
+#'
+#' @export
+vcovUnconditional <- function(type = "HC0", cluster = NULL) {
+    structure(
+        list(type = type, cluster = cluster),
+        class = "marginaleffects_vcov_unconditional"
+    )
+}
+
+
+# Main influence-function calculation --------------------------------------
+
+# Coordinate the complete unconditional-SE calculation for a recorded plan.
+# This is the main bridge between the generic predictions/comparisons pipeline
+# and the mathematical decomposition in equation (5) of the paper:
+#
+#   IF_i(theta) = empirical_i(theta) + J_beta(theta) IF_i(beta).
+#
+# The helpers below construct the two terms separately. Keeping them at the
+# observation level until the end retains their covariance, which is one term
+# needed for robustness to conditional-mean model misspecification. Full
+# robustness also depends on the supplied score and bread representing the
+# derivative of the model's estimating equations.
+plan_unconditional_se <- function(
+    built,
+    mfx,
+    estimates,
+    type,
+    unconditional,
+    dots = list(),
+    contrast_data = NULL,
+    variables = NULL,
+    numderiv = NULL) {
+
+    if (!is.null(mfx) && !is.null(mfx@draws)) {
+        stop_sprintf(
+            "`vcov = \"unconditional\"` is not supported for models or prediction methods that return posterior draws."
+        )
+    }
+
+    inference_cols <- intersect(
+        c("std.error", "statistic", "p.value", "s.value", "conf.low", "conf.high", "df"),
+        colnames(estimates)
+    )
+    if (length(inference_cols) > 0) {
+        estimates[inference_cols] <- NULL
+    }
+
+    plan <- built$plan
+    kind <- plan$kind
+    if (!isTRUE(kind %in% c("predictions", "comparisons"))) {
+        stop_sprintf("Unknown plan kind: %s", kind %||% "NULL")
+    }
+
+    model <- mfx@model
+    validate_unconditional_model_support(model, kind)
+    modeldata <- data.table::as.data.table(mfx@modeldata)
+    n <- nrow(modeldata)
+    allow_mismatch <- get_unconditional_allow_mismatch(mfx, variables)
+    numderiv <- tryCatch(mfx@numderiv, error = function(e) numderiv) %||% list("fdforward")
+
+    rowid <- sanitize_unconditional_plan(
+        plan = plan,
+        model = model,
+        modeldata = modeldata,
+        n = n,
+        n_estimates = nrow(estimates),
+        allow_mismatch = allow_mismatch
+    )
+
+    # Derivative of every final estimand with respect to beta. This includes
+    # comparisons, aggregation, and hypotheses recorded in the plan.
+    J <- get_unconditional_plan_jacobian(
+        plan = plan,
+        mfx = mfx,
+        estimates = estimates,
+        type = type,
+        dots = dots,
+        kind = kind,
+        contrast_data = contrast_data,
+        variables = variables,
+        numderiv = numderiv
+    )
+
+    # Empirical component: variation from averaging over the observed
+    # covariate distribution, holding beta fixed.
+    empirical_phi <- get_unconditional_empirical_phi(
+        plan = plan,
+        model = model,
+        n = n,
+        rowid = rowid,
+        numderiv = numderiv
+    )
+
+    if (ncol(empirical_phi) != nrow(J)) {
+        stop_sprintf(
+            "Internal error: empirical unconditional influence has %d columns, but the Jacobian has %d rows.",
+            ncol(empirical_phi), nrow(J)
+        )
+    }
+
+    # Equation (22)/(25): one row per observation, one column per coefficient.
+    beta_dot <- get_unconditional_beta_dot(model)
+    if (nrow(beta_dot) != n) {
+        stop_sprintf(
+            "`vcov = \"unconditional\"` requires one score row per model-data row."
+        )
+    }
+    if (is.null(colnames(J)) || anyNA(colnames(J)) || any(colnames(J) == "")) {
+        stop_sprintf("The unconditional effect Jacobian must have named coefficient columns.")
+    }
+    missing_beta <- setdiff(colnames(J), colnames(beta_dot))
+    missing_jacobian <- setdiff(colnames(beta_dot), colnames(J))
+    if (length(missing_beta) > 0 || length(missing_jacobian) > 0) {
+        missing <- unique(c(missing_beta, missing_jacobian))
+        stop_sprintf(
+            "The unconditional score matrix does not match the effect Jacobian. Missing columns: %s.",
+            paste(missing, collapse = ", ")
+        )
+    }
+    cols <- colnames(J)
+    # Coefficient component in equations (5), (8), (14), and (17):
+    # IF_i(beta)' J_beta(theta), for every observation and estimand.
+    beta_phi <- beta_dot[, cols, drop = FALSE] %*% t(J[, cols, drop = FALSE])
+
+    # Sum before taking cross-products. Expanding this square preserves the two
+    # cross-covariance terms omitted by the simplified variance estimator in
+    # equation (18); the result corresponds to the complete estimator in (17).
+    Phi <- empirical_phi + beta_phi
+    inputs <- list(
+        n = n,
+        k = attr(beta_dot, "score_dimension", exact = TRUE),
+        vcov = unconditional$vcov
+    )
+    # Phi contains influence values, not per-estimate score contributions.
+    # get_unconditional_vcov() therefore applies the n^-2 scaling required for
+    # the covariance of the sample estimator.
+    V <- get_unconditional_vcov(Phi, inputs)
+    se <- sqrt(diag(V))
+    se[se == 0] <- NA_real_
+
+    estimates$std.error <- as.vector(se)
+    if (unconditional_df_has_finite(mfx@df)) {
+        estimates$df <- mfx@df
+    }
+
+    mfx@vcov_model <- V
+    mfx@vcov_type <- if (!is.null(unconditional$vcov$cluster)) {
+        sprintf("Unconditional (clustered by %s)", unconditional$vcov$cluster_var)
+    } else {
+        "Unconditional"
+    }
+    mfx@jacobian <- diag(nrow(V))
+
+    list(mfx = mfx, estimates = estimates)
+}
+
+
+# Estimand Jacobian ---------------------------------------------------------
+
+# Differentiate the complete recorded estimand with respect to model
+# coefficients. Replaying the plan ensures J describes exactly what is shown
+# to the user, including nonlinear comparisons, averages, and hypotheses.
+get_unconditional_plan_jacobian <- function(
+    plan,
+    mfx,
+    estimates,
+    type,
+    dots,
+    kind,
+    contrast_data = NULL,
+    variables = NULL,
+    numderiv = NULL) {
+
+    # This path combines the derivative with observation-level influence
+    # functions instead of a coefficient covariance matrix, so the resolver is
+    # asked for the Jacobian alone and no covariance is ever propagated here.
+    # Numerical differentiation only: eligibility for the analytic derivative
+    # is decided for the delta method, whose fallbacks differ from the ones
+    # this decomposition requires.
+    jac <- compute_plan_jacobian(
+        plan = plan,
+        mfx = mfx,
+        estimates = estimates,
+        type = type,
+        kind = kind,
+        dots = dots,
+        contrast_data = contrast_data,
+        variables = variables,
+        numderiv = numderiv,
+        analytic = FALSE
+    )
+
+    J <- jac$jacobian
+    if (!isTRUE(checkmate::check_matrix(J, mode = "numeric", nrows = nrow(estimates)))) {
+        stop_sprintf("Unable to compute the unconditional effect Jacobian.")
+    }
+    J
+}
+
+
+# Empirical-distribution linearization -------------------------------------
+
+# Construct the empirical influence component from a common base representation:
+# estimates, source-row IDs, and any influence values already created by a
+# scalar comparison. At this stage model coefficients are fixed; coefficient
+# uncertainty is added once, centrally, in plan_unconditional_se().
+get_unconditional_empirical_phi <- function(
+    plan,
+    model,
+    n,
+    rowid,
+    numderiv = list("fdforward")) {
+
+    if (identical(plan$kind, "predictions")) {
+        estimate <- prediction_plan_predict(plan, model)
+        if (!is.null(plan$keep)) {
+            estimate <- estimate[plan$keep]
+        }
+        base <- list(
+            estimate = estimate,
+            rowid = rowid,
+            phi = NULL
+        )
+    } else {
+        base <- get_unconditional_comparison_base(plan, model, rowid, n)
+    }
+
+    phi <- get_unconditional_aggregate_phi(
+        agg = plan$agg,
+        base_est = base$estimate,
+        rowid = base$rowid,
+        n = n,
+        base_phi = base$phi
+    )
+
+    apply_unconditional_hypothesis_phi(phi, plan, base$estimate, numderiv = numderiv)
+}
+
+
+# Reconstruct comparison estimates at fixed beta and attach an empirical
+# influence column to each one. Vector-valued comparison functions remain at
+# the unit level. Scalar functions have already aggregated several rows, so
+# their influence functions must be constructed here explicitly.
+get_unconditional_comparison_base <- function(plan, model, rowid, n) {
+    preds <- comparison_plan_predict(plan, model)
+    hi <- preds$hi
+    lo <- preds$lo
+    y <- preds$or
+
+    if (!is.null(plan$na_keep)) {
+        hi <- hi[plan$na_keep]
+        lo <- lo[plan$na_keep]
+        if (!is.null(y)) {
+            y <- y[plan$na_keep]
+        }
+        rowid <- rowid[plan$na_keep]
+    }
+    if (!is.null(plan$perm)) {
+        hi <- hi[plan$perm]
+        lo <- lo[plan$perm]
+        if (!is.null(y)) {
+            y <- y[plan$perm]
+        }
+        rowid <- rowid[plan$perm]
+    }
+
+    est <- numeric(plan$n_comp)
+    est_rowid <- rep(NA_integer_, plan$n_comp)
+    phi <- matrix(0, nrow = n, ncol = plan$n_comp)
+
+    for (g in plan$groups) {
+        args <- g$args
+        args$hi <- hi[g$idx]
+        args$lo <- lo[g$idx]
+        if (isTRUE(g$uses_y)) {
+            args$y <- y[g$idx]
+        }
+        con <- do_call(g$fun, args)
+        if (length(con) != length(g$out_idx)) {
+            stop_sprintf("Internal error: comparison plan group changed shape.")
+        }
+        if (length(con) == 1L && !is.finite(con)) {
+            stop_sprintf(
+                "`vcov = \"unconditional\"` requires scalar comparison functions to return a finite value."
+            )
+        }
+
+        est[g$out_idx] <- con
+        if (length(con) == length(g$idx)) {
+            est_rowid[g$out_idx] <- rowid[g$idx]
+        } else if (length(con) == 1L && length(g$idx) > 1L) {
+            phi[, g$out_idx] <- get_unconditional_scalar_comparison_phi(
+                group = g,
+                hi = hi,
+                lo = lo,
+                y = y,
+                rowid = rowid,
+                n = n
+            )
+        }
+    }
+
+    if (!is.null(plan$est_keep)) {
+        est <- est[plan$est_keep]
+        est_rowid <- est_rowid[plan$est_keep]
+        phi <- phi[, plan$est_keep, drop = FALSE]
+    }
+
+    list(estimate = est, rowid = est_rowid, phi = phi)
+}
+
+
+# Linearize a scalar comparison over one group. Known smooth contrasts use
+# analytic empirical influence functions. Arbitrary user functions fall back
+# to delete-one jackknife pseudo-values, which provide a generic first-order
+# approximation when no analytic empirical influence function is available.
+subset_unconditional_delete_one_arg <- function(x, keep, n) {
+    # Observation-level tabular arguments such as `newdata` must be subset by
+    # row. `length(data.frame)` counts columns and can therefore leave newdata
+    # untouched—or accidentally delete columns—inside a delete-one loop.
+    if (is.data.frame(x) || is.matrix(x)) {
+        if (nrow(x) == n) {
+            return(x[keep, , drop = FALSE])
+        }
+        return(x)
+    }
+    if (is.atomic(x) && length(x) == n) {
+        return(x[keep])
+    }
+    x
+}
+
+
+get_unconditional_scalar_comparison_phi <- function(group, hi, lo, y, rowid, n) {
+    # For unweighted targets, differences and positive-mean log ratios match
+    # Hansen–Overgaard (2024), equation (17) and Corollary 9. Ratios follow
+    # from their multivariate result by the delta method; negative-mean log
+    # ratios, log odds ratios, lifts, and weighted targets are extensions.
+    # Prefer these analytic forms to delete-one approximations for known
+    # contrasts.
+    out <- get_unconditional_known_scalar_comparison_phi(
+        group = group,
+        hi = hi,
+        lo = lo,
+        rowid = rowid,
+        n = n
+    )
+    if (!is.null(out)) {
+        return(out)
+    }
+
+    idx <- group$idx
+    ng <- length(idx)
+    out <- numeric(n)
+    if (ng <= 1) {
+        return(out)
+    }
+
+    theta_minus <- numeric(ng)
+    for (j in seq_along(idx)) {
+        keep <- seq_along(idx) != j
+        args <- group$args
+        args <- lapply(
+            args,
+            subset_unconditional_delete_one_arg,
+            keep = keep,
+            n = ng
+        )
+        args$hi <- hi[idx][keep]
+        args$lo <- lo[idx][keep]
+        if (isTRUE(group$uses_y)) {
+            args$y <- y[idx][keep]
+        }
+        value <- do_call(group$fun, args)
+        if (length(value) != 1L || !is.finite(value)) {
+            stop_sprintf(
+                "`vcov = \"unconditional\"` could not linearize a scalar comparison function because a delete-one estimate was not finite."
+            )
+        }
+        theta_minus[[j]] <- value
+    }
+
+    # Center at the mean delete-one estimate. For a nonlinear statistic, the
+    # full-sample estimate need not equal that mean; centering at `theta` would
+    # produce empirical influence values which do not sum to zero.
+    theta_minus_mean <- mean(theta_minus)
+    for (j in seq_along(idx)) {
+        # n/ng converts a group-average contribution to an influence value on
+        # the full-sample n^-1 sum scale used throughout.
+        out[rowid[idx[j]]] <- out[rowid[idx[j]]] +
+            (n / ng) * (ng - 1) * (theta_minus_mean - theta_minus[[j]])
+    }
+    out
+}
+
+
+# Exact empirical influence functions for built-in scalar averages. These are
+# applications of the delta method to group means. In particular,
+# `lnratioavg` matches Corollary 9 on its positive-mean domain and extends the
+# same algebra to two negative means; `differenceavg` implements the empirical
+# part of equation (17). Weighted variants target the corresponding weighted
+# empirical distribution.
+get_unconditional_known_scalar_comparison_phi <- function(
+    group,
+    hi,
+    lo,
+    rowid,
+    n) {
+
+    key <- group$fun_key
+    supported <- c(
+        "differenceavg", "differenceavgwts",
+        "ratioavg", "ratioavgwts",
+        "lnratioavg", "lnratioavgwts",
+        "lnoravg", "lnoravgwts",
+        "liftavg", "liftavgwts"
+    )
+    if (length(key) != 1L || is.na(key) || !key %in% supported) {
+        return(NULL)
+    }
+
+    idx <- group$idx
+    hi <- hi[idx]
+    lo <- lo[idx]
+    rid <- rowid[idx]
+    weighted <- endsWith(key, "wts")
+    w <- if (weighted) group$args$w else rep(1, length(idx))
+    if (length(w) != length(idx) || anyNA(w) || any(!is.finite(w)) || sum(w) == 0) {
+        return(NULL)
+    }
+
+    mean_hi <- sum(w * hi) / sum(w)
+    mean_lo <- sum(w * lo) / sum(w)
+    key <- sub("wts$", "", key)
+
+    unit_phi <- switch(
+        key,
+        differenceavg = (hi - lo) - (mean_hi - mean_lo),
+        ratioavg = {
+            if (mean_lo == 0) return(NULL)
+            (hi - mean_hi) / mean_lo -
+                mean_hi * (lo - mean_lo) / mean_lo^2
+        },
+        lnratioavg = {
+            ratio <- mean_hi / mean_lo
+            if (
+                !is.finite(mean_hi) || !is.finite(mean_lo) ||
+                    mean_hi == 0 || mean_lo == 0 ||
+                    !is.finite(ratio) || ratio <= 0
+            ) {
+                return(NULL)
+            }
+            (hi - mean_hi) / mean_hi - (lo - mean_lo) / mean_lo
+        },
+        lnoravg = {
+            if (mean_hi <= 0 || mean_hi >= 1 || mean_lo <= 0 || mean_lo >= 1) {
+                return(NULL)
+            }
+            (hi - mean_hi) / (mean_hi * (1 - mean_hi)) -
+                (lo - mean_lo) / (mean_lo * (1 - mean_lo))
+        },
+        liftavg = {
+            if (mean_lo == 0) return(NULL)
+            (hi - mean_hi) / mean_lo -
+                mean_hi * (lo - mean_lo) / mean_lo^2
+        }
+    )
+
+    # For equal weights this multiplier is n/ng, matching 1/P(V = v) in the
+    # subgroup influence function (11). With sampling weights it becomes the
+    # empirical analogue n*w_i/sum(w).
+    contribution <- n * w / sum(w) * unit_phi
+    rowsum_unconditional(contribution, rid, n)
+}
+
+
+# Aggregate empirical influence values using the exact groups and weights
+# recorded by the estimation plan. For an unweighted subgroup, the direct term
+# is n/m * (estimate_i - subgroup_mean), matching equations (11) and (14).
+# `base_phi` carries influence already created by a scalar comparison through a
+# possible second aggregation stage.
+get_unconditional_aggregate_phi <- function(agg, base_est, rowid, n, base_phi = NULL) {
+    if (is.null(base_phi)) {
+        base_phi <- matrix(0, nrow = n, ncol = length(base_est))
+    }
+
+    if (is.null(agg)) {
+        return(base_phi)
+    }
+
+    out <- matrix(0, nrow = n, ncol = agg$n)
+
+    for (block in agg$blocks) {
+        idx_mat <- block$idx
+        e <- base_est[idx_mat]
+        dim(e) <- dim(idx_mat)
+        rid <- rowid[idx_mat]
+        dim(rid) <- dim(idx_mat)
+
+        if (isTRUE(agg$weighted)) {
+            w <- block$w
+        } else {
+            w <- matrix(1, nrow = nrow(idx_mat), ncol = ncol(idx_mat))
+        }
+
+        for (j in seq_along(block$cols)) {
+            col <- block$cols[[j]]
+            idx <- idx_mat[, j]
+            ej <- e[, j]
+            rj <- rid[, j]
+            wj <- w[, j]
+            ok <- !is.na(ej) & !is.na(wj) & wj != 0
+            if (!any(ok)) {
+                next
+            }
+            # theta and alpha replay the displayed (possibly weighted) mean.
+            theta <- sum(ej[ok] * wj[ok]) / sum(wj[ok])
+            alpha <- numeric(length(ej))
+            alpha[ok] <- wj[ok] / sum(wj[ok])
+            # Linear combinations of already-linearized scalar estimates.
+            out[, col] <- out[, col] + as.vector(base_phi[, idx, drop = FALSE] %*% alpha)
+
+            # Direct empirical-distribution contribution of this average.
+            ok_rowid <- ok & !is.na(rj)
+            if (any(ok_rowid)) {
+                contrib <- numeric(length(ej))
+                contrib[ok_rowid] <- n * wj[ok_rowid] / sum(wj[ok]) * (ej[ok_rowid] - theta)
+                out[, col] <- out[, col] + rowsum_unconditional(contrib[ok_rowid], rj[ok_rowid], n)
+            }
+        }
+    }
+
+    out[is.na(out)] <- 0
+    out
+}
+
+
+# Propagate empirical influence values through a post-aggregation hypothesis.
+# If h is the hypothesis map, the delta method gives IF(h(theta)) = H IF(theta).
+apply_unconditional_hypothesis_phi <- function(
+    phi,
+    plan,
+    pre_hypothesis_estimate,
+    numderiv = list("fdforward")) {
+
+    if (is.null(plan$hyp)) {
+        return(phi)
+    }
+
+    if (is.null(plan$agg)) {
+        theta <- pre_hypothesis_estimate
+    } else {
+        theta <- apply_plan_aggregation(plan$agg, pre_hypothesis_estimate)
+    }
+
+    # The compiled stage supplies its own derivative when it has one: an affine
+    # hypothesis differentiated numerically would subtract two numbers of the
+    # offset's magnitude and lose the variance to cancellation.
+    res <- hypothesis_stage_pullback(plan$hyp, t(phi), at = theta)
+    if (!is.null(res)) {
+        return(t(res$jacobian))
+    }
+
+    H <- get_jacobian(
+        func = plan$hyp$apply,
+        x = theta,
+        numderiv = numderiv
+    )
+    phi %*% t(H)
+}
+
+
+# Accumulate contributions that map to the same original observation. This is
+# necessary for counterfactual grids, where several evaluation rows can share a
+# single rowid/rowidcf and hence a single sampling unit.
+rowsum_unconditional <- function(x, group, n) {
+    out <- numeric(n)
+    s <- rowsum(x, group, reorder = FALSE)
+    idx <- as.integer(rownames(s))
+    out[idx] <- s[, 1]
+    out
+}
+
+
+# Model-coefficient influence functions ------------------------------------
+
+# Extract the coefficient vector while rejecting aliased models, for which the
+# score/bread columns cannot be put in one-to-one correspondence with beta.
+get_unconditional_coef <- function(model) {
+    beta <- get_coef(model)
+    if (anyNA(beta)) {
+        stop_sprintf("`vcov = \"unconditional\"` does not support models with aliased coefficients.")
+    }
+    beta
+}
+
+
+# Construct observation-level IF(beta). Under the sandwich convention,
+# estfun() supplies estimating-function contributions and bread() supplies the
+# inverse derivative matrix, so scores %*% bread is the plug-in version of
+# equation (22)/(25). Model-specific branches normalize this same contract.
+# Supporting models with nuisance parameters requires retaining their full
+# score/bread system and, when relevant, including them in the estimand Jacobian.
+get_unconditional_beta_dot <- function(model) {
+    insight::check_if_installed("sandwich")
+    if (inherits(model, "svyglm")) {
+        # Inspired by Noah Greifer's implementation in the adrftools package.
+        # survey::svyglm() can save the observation-level coefficient
+        # influence function when called with influence = TRUE. Reconstruct
+        # the same matrix when it was not saved (the default). The factor n
+        # converts survey's per-observation representation to the influence
+        # convention used by the unconditional covariance calculation below.
+        n <- nrow(stats::model.frame(model))
+        scores <- attr(model, "influence", exact = TRUE)
+        if (is.null(scores)) {
+            scores <- tcrossprod(
+                stats::model.matrix(model) *
+                    stats::residuals(model, type = "working") *
+                    model$weights,
+                model$naive.cov
+            )
+        }
+        scores <- n * scores
+        bread <- diag(ncol(scores))
+        dimnames(bread) <- list(colnames(scores), colnames(scores))
+    } else if (inherits(model, "fixest")) {
+        insight::check_if_installed("fixest")
+        scores <- model$scores
+        bread <- tryCatch(
+            fixest::bread(model),
+            error = function(e) {
+                msg <- paste0(
+                    "`vcov = \"unconditional\"` requires model scores and a ",
+                    "bread matrix. `fixest::bread()` failed for this model: %s"
+                )
+                stop_sprintf(
+                    msg,
+                    conditionMessage(e)
+                )
+            }
+        )
+    } else {
+        scores <- tryCatch(
+            sandwich::estfun(model),
+            error = function(e) {
+                msg <- paste0(
+                    "`vcov = \"unconditional\"` requires a ",
+                    "`sandwich::estfun()` method for models of class \"%s\". ",
+                    "Original error: %s"
+                )
+                stop_sprintf(
+                    msg,
+                    class(model)[1],
+                    conditionMessage(e)
+                )
+            }
+        )
+        # For noncanonical GLMs, sandwich::bread.glm() uses the Fisher/IRLS
+        # sensitivity and omits the residual-dependent derivative term in
+        # Hansen--Overgaard equation (21). The resulting unconditional
+        # variance is asymptotically justified when the conditional mean is
+        # correctly specified, but is not fully robust to mean
+        # misspecification. Supporting that case would require an empirical
+        # Jacobian of the actual GLM score equations, including offsets, prior
+        # weights, and dispersion conventions.
+        bread <- tryCatch(
+            sandwich::bread(model),
+            error = function(e) {
+                msg <- paste0(
+                    "`vcov = \"unconditional\"` requires a ",
+                    "`sandwich::bread()` method for models of class \"%s\". ",
+                    "Original error: %s"
+                )
+                stop_sprintf(
+                    msg,
+                    class(model)[1],
+                    conditionMessage(e)
+                )
+            }
+        )
+    }
+
+    beta <- get_unconditional_coef(model)
+    if (is.null(names(beta)) || anyNA(names(beta)) || any(names(beta) == "")) {
+        stop_sprintf("`vcov = \"unconditional\"` requires named model coefficients.")
+    }
+    if (!isTRUE(checkmate::check_matrix(scores, min.rows = 1, min.cols = 1))) {
+        stop_sprintf(
+            "`vcov = \"unconditional\"` could not extract a valid score matrix for this model."
+        )
+    }
+    # `sandwich::meatCL()` defines k as the number of estimating-function
+    # columns. Preserve that dimension before selecting the coefficients used
+    # by the target Jacobian. This is intentionally distinct from the `df`
+    # value used for t or normal inference in the calling function.
+    score_dimension <- ncol(scores)
+    if (!isTRUE(checkmate::check_matrix(bread, nrows = ncol(scores), ncols = ncol(scores)))) {
+        stop_sprintf(
+            "`vcov = \"unconditional\"` could not extract a valid bread matrix for this model."
+        )
+    }
+    if (is.null(colnames(scores)) && ncol(scores) == length(beta)) {
+        colnames(scores) <- names(beta)
+    }
+    if (is.null(colnames(bread)) && ncol(bread) == length(beta)) {
+        colnames(bread) <- names(beta)
+    }
+    if (is.null(rownames(bread)) && nrow(bread) == length(beta)) {
+        rownames(bread) <- names(beta)
+    }
+
+    cols <- names(beta)
+    missing_scores <- setdiff(cols, colnames(scores))
+    missing_bread_rows <- setdiff(cols, rownames(bread))
+    missing_bread_cols <- setdiff(cols, colnames(bread))
+    if (length(missing_scores) > 0 || length(missing_bread_rows) > 0 || length(missing_bread_cols) > 0) {
+        missing <- unique(c(missing_scores, missing_bread_rows, missing_bread_cols))
+        msg <- paste0(
+            "`vcov = \"unconditional\"` could not align model coefficients ",
+            "with the score and bread matrices. Missing columns: %s."
+        )
+        stop_sprintf(msg, paste(missing, collapse = ", "))
+    }
+
+    scores <- scores[, cols, drop = FALSE]
+    bread <- bread[cols, cols, drop = FALSE]
+    out <- scores %*% bread
+    attr(out, "score_dimension") <- score_dimension
+    out
+}
+
+
+# Covariance assembly -------------------------------------------------------
+
+# Convert the n by q influence matrix into the q by q covariance of q
+# estimators. IID inference uses sum_i Phi_i Phi_i' / n^2. Clustered inference
+# first sums Phi within clusters, which retains arbitrary within-cluster
+# dependence before taking the cross-product.
+get_unconditional_vcov <- function(Phi, inputs) {
+    n <- inputs$n
+    correction <- get_unconditional_correction(inputs)
+    if (!is.null(inputs$vcov$cluster)) {
+        S <- rowsum(Phi, inputs$vcov$cluster, reorder = FALSE)
+        return(crossprod(S) / n^2 * correction)
+    }
+    crossprod(Phi) / n^2 * correction
+}
+
+
+# Apply the conventional sandwich-style finite-sample corrections after
+# constructing the asymptotic plug-in covariance. The model correction and
+# cluster-count correction are separate: HC0 omits the former, while clustered
+# HC0 still follows sandwich::vcovCL()'s default `cadjust = TRUE` behavior.
+# These multipliers are API conventions for the complete target influence
+# function, not finite-sample corrections derived by Hansen and Overgaard.
+get_unconditional_correction <- function(inputs) {
+    clustered <- !is.null(inputs$vcov$cluster)
+    n <- inputs$n
+    cluster_adjustment <- 1
+    if (clustered) {
+        G <- length(unique(inputs$vcov$cluster))
+        if (G < 2) stop_sprintf("Cluster-robust unconditional variance requires at least two clusters.")
+        cluster_adjustment <- G / (G - 1)
+    }
+    if (inputs$vcov$type == "HC0") {
+        return(cluster_adjustment)
+    }
+    k <- inputs$k
+    if (
+        length(k) != 1L ||
+            !is.numeric(k) ||
+            !is.finite(k) ||
+            k < 1 ||
+            k != as.integer(k)
+    ) {
+        stop_sprintf("`vcov = \"unconditional\"` could not determine the dimension of the model estimating-function system required for `type = \"HC1\"`.")
+    }
+    if (n <= k) {
+        stop_sprintf("`vcov = \"unconditional\"` requires more observations than model estimating functions for `type = \"HC1\"`. Use `vcovUnconditional(type = \"HC0\")` to omit the model degrees-of-freedom correction.")
+    }
+    if (clustered) {
+        return(cluster_adjustment * ((n - 1) / (n - k)))
+    }
+    n / (n - k)
+}
+
+
+# Output propagation --------------------------------------------------------
+
+# Decide whether finite degrees of freedom should be copied into the displayed
+# estimates. The value itself is inherited from the user-facing function and is
+# deliberately not computed by the unconditional variance machinery.
+unconditional_df_has_finite <- function(df) {
+    is.numeric(df) && any(is.finite(df))
+}
+
+
+# Apply the multivariate delta method after a user-requested transformation.
+# If g maps the estimate vector to a transformed vector and H is its Jacobian,
+# this replaces V with H V H'. The saved unconditional covariance must be
+# transformed here because finalize_estimates() otherwise transforms only the
+# displayed estimates and standard errors.
+update_unconditional_vcov_transform <- function(mfx, estimate, transform) {
+    vcov_type <- tryCatch(mfx@vcov_type, error = function(e) "")
+    if (!isTRUE(grepl("^Unconditional", vcov_type))) {
+        return(mfx)
+    }
+
+    if (!is.function(transform)) {
+        if (is.null(transform[[1]])) {
+            return(mfx)
+        }
+        transform <- transform[[1]]
+    }
+
+    if (is.null(estimate)) {
+        return(mfx)
+    }
+
+    V <- mfx@vcov_model
+    if (!isTRUE(checkmate::check_matrix(V, mode = "numeric"))) {
+        return(mfx)
+    }
+    if (nrow(V) != ncol(V) || length(estimate) != nrow(V)) {
+        stop_sprintf(
+            "Internal error: unconditional vcov has %d rows but the transformed estimates have length %d.",
+            nrow(V),
+            length(estimate)
+        )
+    }
+
+    estimate <- as.numeric(estimate)
+    if (anyNA(estimate) || any(!is.finite(estimate))) {
+        msg <- paste0(
+            "`vcov = \"unconditional\"` cannot transform the saved covariance ",
+            "matrix when pre-transform estimates are non-finite."
+        )
+        stop_sprintf(msg)
+    }
+
+    transform_checked <- function(x) {
+        out <- transform(x)
+        if (!is.numeric(out) || length(out) != length(x)) {
+            stop_sprintf(
+                "The `transform` function must return a numeric vector with the same length as its input."
+            )
+        }
+        as.numeric(out)
+    }
+
+    H <- tryCatch(
+        get_jacobian(transform_checked, estimate, mfx@numderiv %||% list("fdforward")),
+        error = function(e) {
+            stop_sprintf(
+                "`vcov = \"unconditional\"` could not numerically differentiate the `transform` function: %s",
+                conditionMessage(e)
+            )
+        }
+    )
+    if (!identical(dim(H), c(length(estimate), length(estimate))) || anyNA(H) || any(!is.finite(H))) {
+        stop_sprintf(
+            "`vcov = \"unconditional\"` could not compute a finite transform Jacobian."
+        )
+    }
+
+    V <- H %*% V %*% t(H)
+    V <- (V + t(V)) / 2
+    dimnames(V) <- dimnames(mfx@vcov_model)
+    mfx@vcov_model <- V
+    mfx@jacobian <- diag(nrow(V))
+    mfx
+}

--- a/r/R/vcov_unconditional_sanitization.R
+++ b/r/R/vcov_unconditional_sanitization.R
@@ -1,0 +1,468 @@
+stop_unconditional <- function(reason) {
+    msg <- switch(
+        reason,
+        "hypotheses" = paste0(
+            "`vcov = \"unconditional\"` is only available for predictions, ",
+            "comparisons, and slopes computed by `marginaleffects`. Use ",
+            "`avg_predictions()`, `avg_comparisons()`, or `avg_slopes()` with ",
+            "`vcov = \"unconditional\"`, then call `hypotheses()` on the result ",
+            "if needed."
+        ),
+        "inferences" = paste0(
+            "`inferences()` is not available for objects computed with ",
+            "`vcov = \"unconditional\"`. Use the unconditional standard errors ",
+            "from the original `avg_*()` call, or refit the original call with ",
+            "`vcov = FALSE` before applying `inferences()`."
+        )
+    )
+    if (is.null(msg)) {
+        stop_sprintf("Internal error: unknown unconditional stop reason: %s.", reason %||% "NULL")
+    }
+    stop_sprintf(msg)
+}
+
+sanitize_unconditional_vcov_request <- function(vcov, mfx) {
+    if (!inherits(vcov, "marginaleffects_vcov_unconditional")) {
+        stop_sprintf("Internal error: unconditional vcov sanitization requires a `vcovUnconditional()` object.")
+    }
+
+    calling_function <- tryCatch(mfx@calling_function, error = function(e) NULL)
+    validate_unconditional_model_support(mfx@model, kind = calling_function)
+
+    modeldata <- data.table::as.data.table(mfx@modeldata)
+    auxdata <- if (inherits(vcov$cluster, "formula")) {
+        get_unconditional_auxdata(mfx, nrow(modeldata))
+    }
+    vcov_info <- sanitize_unconditional_vcov_arg(
+        type = vcov$type,
+        cluster = vcov$cluster,
+        modeldata = modeldata,
+        auxdata = auxdata
+    )
+    structure(
+        list(vcov = vcov_info),
+        class = "marginaleffects_vcov_unconditional"
+    )
+}
+
+
+validate_unconditional_model_support <- function(model, kind) {
+    # Deliberately inspect the primary class to reject unvalidated subclasses
+    # such as `mlm`, even when they also inherit from a supported class.
+    primary_class <- class(model)[1]
+
+    # Hansen–Overgaard do not explicitly validate censored or survival models.
+    # Their estimating systems can also contain nuisance parameters whose
+    # influence is not represented by the current coefficient-only Jacobian.
+    if (inherits(model, c("tobit", "survreg", "coxph"))) {
+        msg <- paste0(
+            "`vcov = \"unconditional\"` is not supported for censored or ",
+            "survival models of class \"%s\". These models are outside the ",
+            "currently validated conditional-mean setup and can require ",
+            "additional nuisance-parameter influence functions. Use a ",
+            "bootstrap method instead."
+        )
+        stop_sprintf(msg, primary_class)
+    }
+
+    if (isTRUE(primary_class %in% c("lm", "glm", "svyglm"))) {
+        return(invisible(TRUE))
+    }
+
+    if (inherits(model, "fixest")) {
+        has_fixed_effects <- !is.null(model[["fixef_vars"]])
+        if (!has_fixed_effects) {
+            return(invisible(TRUE))
+        }
+        if (identical(kind, "predictions")) {
+            msg <- paste0(
+                "`vcov = \"unconditional\"` is not supported for average ",
+                "predictions from `fixest` models with fixed effects because ",
+                "fixed-effect uncertainty is not represented."
+            )
+            stop_sprintf(msg)
+        }
+        if (!identical(model[["method_type"]], "feols")) {
+            msg <- paste0(
+                "`vcov = \"unconditional\"` is not supported for nonlinear ",
+                "`fixest` models with fixed effects because fixed-effect ",
+                "uncertainty is not represented."
+            )
+            stop_sprintf(msg)
+        }
+        return(invisible(TRUE))
+    }
+
+    reason <- paste0(
+        "only explicitly validated model classes are supported. ",
+        "Currently supported classes include `lm`, `glm`, `svyglm`, and selected ",
+        "`fixest` models"
+    )
+    msg <- paste0(
+        "`vcov = \"unconditional\"` is not currently supported for models ",
+        "of class \"%s\": %s. Use a bootstrap method instead."
+    )
+    stop_sprintf(
+        msg,
+        class(model)[1],
+        reason
+    )
+}
+
+
+validate_unconditional_plan_target <- function(plan) {
+    scalar_comparison <- identical(plan$kind, "comparisons") &&
+        any(vapply(plan$groups, function(group) {
+            isTRUE(group$scalar) && length(group$idx) > 1L
+        }, logical(1)))
+
+    if (!is.null(plan$agg) || scalar_comparison) {
+        return(invisible(TRUE))
+    }
+
+    if (!is.null(plan$hyp)) {
+        msg <- paste0(
+            "`vcov = \"unconditional\"` does not support `hypothesis` ",
+            "applied directly to unit-level effects. Use an `avg_*()` ",
+            "function, a `by` argument, or a scalar comparison before ",
+            "`hypothesis`."
+        )
+        stop_sprintf(msg)
+    }
+
+    msg <- paste0(
+        "`vcov = \"unconditional\"` is only supported for averaged or ",
+        "aggregated effects. Use an `avg_*()` function, a `by` argument, ",
+        "or a scalar comparison."
+    )
+    stop_sprintf(msg)
+}
+
+
+validate_unconditional_fixest_plan <- function(model, plan) {
+    if (
+        !inherits(model, "fixest") ||
+            is.null(model[["fixef_vars"]]) ||
+            !identical(plan$kind, "comparisons")
+    ) {
+        return(invisible(TRUE))
+    }
+
+    # `fixest::estfun()` and `fixest::bread()` do not expose the individual
+    # absorbed fixed-effect coefficients. For linear `feols` models this is
+    # harmless when the estimand depends only on hi - lo: the same additive
+    # fixed effect appears in both predictions and cancels exactly. dydx and
+    # dyex are rescalings of that difference and inherit the same invariance.
+    # Ratios, prediction-level elasticities, expdydx, and arbitrary functions
+    # can depend on the prediction levels, so fixed-effect uncertainty need not
+    # cancel and those comparisons are rejected conservatively.
+    allowed <- c(
+        "difference", "differenceavg", "differenceavgwts",
+        "dydx", "dydxavg", "dydxavgwts",
+        "dyex", "dyexavg", "dyexavgwts"
+    )
+    fun_keys <- vapply(plan$groups, function(group) {
+        key <- group$fun_key
+        if (length(key) != 1L || is.na(key)) NA_character_ else key
+    }, character(1))
+    invalid <- unique(fun_keys[is.na(fun_keys) | !fun_keys %in% allowed])
+    if (length(invalid) > 0L) {
+        labels <- ifelse(is.na(invalid), "custom function", sprintf("`%s`", invalid))
+        stop_sprintf(
+            paste0(
+                "`vcov = \"unconditional\"` supports `feols` models with fixed effects only for ",
+                "additive differences and `dydx` or `dyex` slopes, where the fixed effects cancel. ",
+                "Unsupported comparison: %s. Use a supported comparison or a bootstrap method."
+            ),
+            toString(labels)
+        )
+    }
+
+    # Use the parsed fixed-effect formula rather than `fixef_vars`: the latter
+    # stores combined effects such as `id^time` as one string. `all.vars()` also
+    # extracts the slope variable from varying-slope terms such as `id[x]`.
+    fixef_formula <- tryCatch(model[["fml_all"]][["fixef"]], error = function(e) NULL)
+    fixef_variables <- tryCatch(all.vars(fixef_formula), error = function(e) character())
+    if (length(fixef_variables) == 0L) {
+        stop_sprintf(
+            paste0(
+                "`vcov = \"unconditional\"` could not identify the fixed-effect variables in this ",
+                "`feols` model, so it cannot verify that fixed effects cancel. Use a bootstrap method."
+            )
+        )
+    }
+
+    hi <- plan$predict_args$hi
+    lo <- plan$predict_args$lo
+    missing <- setdiff(fixef_variables, intersect(colnames(hi), colnames(lo)))
+    if (length(missing) > 0L) {
+        stop_sprintf(
+            paste0(
+                "`vcov = \"unconditional\"` could not verify these fixed-effect or varying-slope ",
+                "variables in the counterfactual data: %s. Use a bootstrap method."
+            ),
+            toString(sprintf("`%s`", missing))
+        )
+    }
+
+    # Exact equality is intentional. A varying-slope variable can change by a
+    # very small finite-difference step, which a tolerance-based comparison
+    # could incorrectly treat as unchanged.
+    changed <- fixef_variables[vapply(
+        fixef_variables,
+        function(variable) !identical(hi[[variable]], lo[[variable]]),
+        logical(1)
+    )]
+    if (length(changed) > 0L) {
+        stop_sprintf(
+            paste0(
+                "`vcov = \"unconditional\"` cannot vary fixed-effect or varying-slope variables ",
+                "because their uncertainty does not cancel: %s. Use a different focal variable or ",
+                "a bootstrap method."
+            ),
+            toString(sprintf("`%s`", changed))
+        )
+    }
+
+    invisible(TRUE)
+}
+
+
+sanitize_unconditional_plan <- function(
+    plan,
+    model,
+    modeldata,
+    n,
+    n_estimates,
+    allow_mismatch = character()) {
+
+    source <- if (identical(plan$kind, "predictions")) {
+        plan$predict_args$newdata
+    } else {
+        plan$predict_args$original
+    }
+    if (identical(plan$kind, "predictions") && !is.null(plan$keep)) {
+        source <- source[plan$keep, , drop = FALSE]
+    }
+
+    msg <- paste0(
+        "`vcov = \"unconditional\"` requires effects evaluated over ",
+        "original model-data rows, a subset of original rows with valid ",
+        "row IDs, or a full counterfactual grid that preserves `rowidcf`."
+    )
+    rowid <- resolve_unconditional_rowid(
+        source,
+        n,
+        modeldata = modeldata,
+        allow_mismatch = allow_mismatch,
+        message = msg
+    )
+
+    validate_unconditional_plan_target(plan)
+    validate_unconditional_fixest_plan(model, plan)
+
+    rowid
+}
+
+
+get_unconditional_allow_mismatch <- function(mfx, variables = NULL) {
+    out <- character()
+
+    if (isTRUE(checkmate::check_list(variables))) {
+        for (v in variables) {
+            if (isTRUE(checkmate::check_string(v$name))) {
+                out <- c(out, v$name)
+            }
+        }
+    }
+
+    out <- c(out, tryCatch(mfx@variable_names_datagrid, error = function(e) character()))
+    unique(stats::na.omit(out))
+}
+
+
+resolve_unconditional_rowid <- function(
+    x,
+    n,
+    modeldata = NULL,
+    allow_mismatch = character(),
+    message = NULL) {
+
+    if (is.null(message)) {
+        message <- "`vcov = \"unconditional\"` currently requires evaluation rows to map to the original model data."
+    }
+    out <- NULL
+
+    common <- character()
+    if (!is.null(modeldata)) {
+        ignored <- c(
+            "rowid",
+            "rowidcf",
+            "marginaleffects_wts_internal",
+            "rowid_dedup"
+        )
+        common <- intersect(colnames(x), colnames(modeldata))
+        common <- setdiff(common, c(ignored, allow_mismatch))
+    }
+
+    rowid_cols <- intersect(c("rowidcf", "rowid"), colnames(x))
+    for (rowid_col in rowid_cols) {
+        candidate <- as.integer(x[[rowid_col]])
+        if (anyNA(candidate) || !all(candidate %in% seq_len(n))) {
+            next
+        }
+        if (identical(rowid_col, "rowidcf") &&
+            length(allow_mismatch) == 0L &&
+            !setequal(unique(candidate), seq_len(n))) {
+            next
+        }
+        if (is.null(modeldata)) {
+            out <- candidate
+        } else {
+            matches <- vapply(common, function(column) {
+                isTRUE(all.equal(
+                    x[[column]],
+                    modeldata[[column]][candidate],
+                    check.attributes = FALSE
+                ))
+            }, logical(1))
+            if (all(matches)) {
+                out <- candidate
+            }
+        }
+        if (!is.null(out)) {
+            break
+        }
+    }
+
+    if (is.null(out) && !is.null(modeldata)) {
+        matched <- match_unconditional_source_modeldata(
+            x,
+            modeldata,
+            common = common)
+        if (!is.null(matched)) {
+            out <- matched
+        }
+    }
+
+    if (is.null(out) || anyNA(out) || any(out < 1L) || any(out > n)) {
+        stop_sprintf(message)
+    }
+    as.integer(out)
+}
+
+
+match_unconditional_source_modeldata <- function(source, modeldata, common) {
+    source <- data.table::as.data.table(source)
+    modeldata <- data.table::as.data.table(modeldata)
+    if (length(common) == 0) {
+        return(NULL)
+    }
+
+    model_keys <- data.table::copy(modeldata[, common, with = FALSE])
+    if (any(duplicated(model_keys, by = common))) {
+        return(NULL)
+    }
+    model_keys[, ".marginaleffects_unconditional_rowid" := seq_len(.N)]
+    source_keys <- source[, common, with = FALSE]
+    out <- model_keys[source_keys, on = common][[".marginaleffects_unconditional_rowid"]]
+    if (length(out) != nrow(source) || anyNA(out)) {
+        return(NULL)
+    }
+    as.integer(out)
+}
+
+
+sanitize_unconditional_vcov_arg <- function(type, cluster, modeldata, auxdata) {
+    type_choices <- c("HC0", "HC1")
+    type_message <- paste0(
+        "`type` must be one of ",
+        paste(sprintf("\"%s\"", type_choices), collapse = ", "),
+        "."
+    )
+    if (!isTRUE(checkmate::check_character(type, len = 1, any.missing = FALSE))) {
+        stop_sprintf(type_message)
+    }
+    if (toupper(type) %in% c("HC2", "HC3", "HC4", "HC4M", "HC5")) {
+        stop_sprintf(
+            "`type = \"%s\"` is not available for unconditional inference because regression-leverage adjustments are not defined for the combined influence function. Use `type = \"HC0\"` or `type = \"HC1\"`.",
+            type
+        )
+    }
+    idx <- match(tolower(type), tolower(type_choices))
+    if (is.na(idx)) {
+        stop_sprintf(type_message)
+    }
+    type <- type_choices[idx]
+
+    cluster_var <- NULL
+    cluster_values <- NULL
+    if (!is.null(cluster)) {
+        cluster_message <- paste0(
+            "`cluster` must be NULL or a one-sided formula with one bare variable name, ",
+            "such as `~id`, for one-way clustered inference. Transformations and ",
+            "multiple variables are not supported."
+        )
+        if (
+            !isTRUE(checkmate::check_formula(cluster)) ||
+                length(cluster) != 2L ||
+                !is.symbol(cluster[[2L]])
+        ) {
+            stop_sprintf(cluster_message)
+        }
+        # Do not use `all.vars()` here: it would accept expressions such as
+        # `~floor(id / 10)` and then silently extract the untransformed `id`.
+        # Requiring a symbol makes the formula an unambiguous column reference.
+        cluster_var <- as.character(cluster[[2L]])
+        if (cluster_var %in% colnames(modeldata)) {
+            cluster_values <- modeldata[[cluster_var]]
+        } else if (cluster_var %in% colnames(auxdata)) {
+            cluster_values <- auxdata[[cluster_var]]
+        } else {
+            stop_sprintf(
+                "Cluster variable \"%s\" was not found in the model data.",
+                cluster_var
+            )
+        }
+        if (length(cluster_values) != nrow(modeldata)) {
+            stop_sprintf(
+                "Cluster variable \"%s\" has length %d, but the model data have %d rows.",
+                cluster_var,
+                length(cluster_values),
+                nrow(modeldata)
+            )
+        }
+        if (anyNA(cluster_values)) {
+            stop_sprintf("Cluster variable \"%s\" contains missing values.", cluster_var)
+        }
+        if (length(unique(cluster_values)) < 2) {
+            stop_sprintf("Cluster-robust unconditional variance requires at least two clusters.")
+        }
+    }
+
+    list(type = type, cluster = cluster_values, cluster_var = cluster_var)
+}
+
+
+get_unconditional_auxdata <- function(mfx, n) {
+    auxdata <- data.table::as.data.table(mfx@newdata)
+    if ("rowid" %in% colnames(auxdata)) {
+        auxdata <- auxdata[!duplicated(rowid)]
+    } else if (nrow(auxdata) > n) {
+        auxdata <- auxdata[seq_len(n)]
+    }
+    if (nrow(auxdata) != n) {
+        auxdata <- data.table::as.data.table(mfx@modeldata)
+    }
+    additional_data <- tryCatch(
+        data.table::as.data.table(get_modeldata(mfx@model, additional_variables = TRUE)),
+        error = function(e) NULL
+    )
+    if (!is.null(additional_data) && nrow(additional_data) == n) {
+        additional_columns <- setdiff(colnames(additional_data), colnames(auxdata))
+        if (length(additional_columns) > 0) {
+            auxdata <- cbind(auxdata, additional_data[, additional_columns, with = FALSE])
+        }
+    }
+    auxdata
+}

--- a/r/R/zzz.R
+++ b/r/R/zzz.R
@@ -26,14 +26,4 @@
 
 .onLoad <- function(lib, pkg) {
     backports::import(pkg)
-    if (isNamespaceLoaded("reticulate")) {
-        py_require_marginaleffects()
-    } else {
-        setHook(packageEvent("reticulate", "onLoad"), py_require_marginaleffects)
-    }
-}
-
-py_require_marginaleffects <- function(...) {
-    reticulate::py_require("marginaleffects")
-    reticulate::py_require("jax")
 }


### PR DESCRIPTION
Review-only branch: the `r/R/` subset of the `jacobian-stage-composition` work, isolated so it can be reviewed on its own. Opened as a draft — not intended to merge as-is.

## Scope
46 files, +3798 / -849.

**New files**
- `r/R/vcov_unconditional.R` (+968)
- `r/R/vcov_unconditional_sanitization.R` (+468)
- `r/R/jacobian_stage.R` (+111)

**Largest rewrites**
- `r/R/get_jacobian_analytic.R` (+731/-…)
- `r/R/plan_replay.R` (+487/-…)
- `r/R/hypothesis_compile.R` (+409/-…)
- `r/R/get_se_delta.R`, `r/R/sanitize_comparison.R`, `r/R/get_model_matrix.R`, `r/R/hypotheses.R`

Plus smaller touches across the `methods_*.R` model adapters, the `*_plan_*.R` files, and assorted sanitizers.

## Review focus
Standard-error and Jacobian correctness — the delta-method paths, the new unconditional-vcov machinery, and the per-model-class adapters that feed them.