### PR TITLE
Modify matching description and update function usage

### DIFF
--- a/website/bonus/matching.qmd
+++ b/website/bonus/matching.qmd
@@ -26,14 +26,14 @@ We are interested in the treatment effect of the `treat` variable on the `re78` 
 
 ## Matching
 
-The first step is to pre-process the dataset to achieve better covariate balance. To do this, we use the `MatchIt::matchit()` function and a 1-to-1 nearest neighbor matching with replacement on the Mahaloanobis distance. This function supports many other matching methods, see `?matchit`.
+The first step is to pre-process the dataset to achieve better covariate balance. To do this, we use the `MatchIt::matchit()` function and a 1-to-1 nearest neighbor matching without replacement on the Mahalanobis distance. This function supports many other matching methods, including propensity score matching; see `?matchit`.
 
 ```{r}
 dat <- matchit(
     treat ~ age + educ + race + married + nodegree + re74 + re75, 
-    data = lalonde, distance = "mahalanobis",
-    replace = FALSE)
-dat <- match.data(dat)
+    data = lalonde, distance = "mahalanobis")
+
+dat <- match_data(dat)
 ```
 
 ## Fitting
@@ -51,17 +51,16 @@ fit <- lm(
 
 Finally, we use the `avg_comparisons()` function of the `marginaleffects` package to estimate the ATT and its standard error. In effect, this function applies [G-Computation](https://marginaleffects.com/chapters/gcomputation.html) to estimate the quantity of interest. We use the following arguments:
  
-* `variables="treat"` indicates that we are interested in the effect of the `treat` variable.
-* `newdata=subset(dat, treat == 1)` indicates that we want to estimate the effect for the treated individuals only (i.e., the ATT).
-* `wts="weights"` indicates that we want to use the weights supplied by the matching method.
+* `variables = "treat"` indicates that we are interested in the effect of the `treat` variable.
+* `newdata = subset(dat, treat == 1)` indicates that we want to estimate the effect for the treated individuals only (i.e., the ATT).
+* `vcov = ~subclass` indicates that we want to cluster our standard errors by pair membership (contain in the `subclass` variable in `dat`).
 
 ```{r, warning=FALSE}
 avg_comparisons(
     fit,
     variables = "treat",
     newdata = subset(dat, treat == 1),
-    vcov = ~subclass,
-    wts = "weights")
+    vcov = ~subclass)
 ```
 
 See the [MatchIt vignette](https://kosukeimai.github.io/MatchIt/articles/estimating-effects.html) for more details, including a discussion of uncertainty estimation.


### PR DESCRIPTION
Updated description of matching method and corrected function calls, in particular removing `wts` from `avg_comparisons()`.