### PR TITLE
Fix typo in example

### DIFF
--- a/r/R/hypotheses.R
+++ b/r/R/hypotheses.R
@@ -75,7 +75,7 @@
 #' hypotheses(cmp, hypothesis = "b1 = b2")
 #'
 #' mfx <- slopes(mod, newdata = "mean")
-#' hypotheses(cmp, hypothesis = "b2 = 0.2")
+#' hypotheses(mfx, hypothesis = "b2 = 0.2")
 #'
 #' pre <- predictions(mod, newdata = datagrid(hp = 110, mpg = c(30, 35)))
 #' hypotheses(pre, hypothesis = "b1 = b2")

--- a/r/man/hypotheses.Rd
+++ b/r/man/hypotheses.Rd
@@ -235,7 +235,7 @@ cmp <- comparisons(mod, newdata = "mean")
 hypotheses(cmp, hypothesis = "b1 = b2")
 
 mfx <- slopes(mod, newdata = "mean")
-hypotheses(cmp, hypothesis = "b2 = 0.2")
+hypotheses(mfx, hypothesis = "b2 = 0.2")
 
 pre <- predictions(mod, newdata = datagrid(hp = 110, mpg = c(30, 35)))
 hypotheses(pre, hypothesis = "b1 = b2")


### PR DESCRIPTION
This was found with the new `unused_object` rule in Jarl (`mfx` defined on the line above was unused): `jarl check r/R -s unused_object`

FYI there are ~30 cases reported as unused in `r/R`, but I don't know the internals well enough to determine whether those should be removed or if they indicate bugs. Might be worth investigating.

And congrats on 1.0!

---

CI failures look unrelated